### PR TITLE
Added "java" command to JDK

### DIFF
--- a/java/openjdk-jdk.xml
+++ b/java/openjdk-jdk.xml
@@ -12,50 +12,59 @@ IcedTea project.</description>
   <category>Development</category>
 
   <feed arch="Windows-*" src="http://0install.de/feeds/Oracle_JDK.xml"/>
+  <package-implementation distributions="Windows" package="openjdk-7-jdk"/>
+  <package-implementation distributions="Windows" package="openjdk-8-jdk"/>
 
-  <package-implementation distributions="Debian" main="/usr/bin/javac" package="openjdk-7-jdk"/>
-  <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1_7_0-openjdk-devel"/>
-  <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1.7.0-openjdk-devel"/>
-  <package-implementation distributions="Windows Darwin" package="openjdk-7-jdk"/>
-  <package-implementation distributions="Windows Darwin" package="openjdk-8-jdk"/>
-
-  <package-implementation main="/usr/bin/javac" package="openjdk-6-jdk"/>
-  <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1_6_0-openjdk-devel"/>
-  <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1.6.0-openjdk-devel"/>
-
-  <group main="bin/javac" arch="POSIX-*">
-    <command name="run">
+  <group>
+    <!-- Windows versions of the JDK bundle their own copy of the JRE. On POSIX systems we refer back the regular JRE. -->
+    <command name="java">
       <runner interface="http://repo.roscidus.com/java/openjdk-jre"/>
-      <arg>-cp</arg><arg>${JDK_CLASSPATH}</arg>
-      <arg>com.sun.tools.javac.Main</arg>
     </command>
 
-    <environment insert="lib/sa-jdi.jar" name="JDK_CLASSPATH"/>
-    <environment insert="lib/tools.jar" name="JDK_CLASSPATH"/>
-    <environment insert="lib/jconsole.jar" name="JDK_CLASSPATH"/>
-    <environment insert="lib/dt.jar" name="JDK_CLASSPATH"/>
+    <package-implementation distributions="Debian" main="/usr/bin/javac" package="openjdk-7-jdk"/>
+    <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1_7_0-openjdk-devel"/>
+    <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1.7.0-openjdk-devel"/>
+    <package-implementation distributions="Darwin" package="openjdk-7-jdk"/>
+    <package-implementation distributions="Darwin" package="openjdk-8-jdk"/>
 
-    <group>
-      <requires interface="http://repo.roscidus.com/java/openjdk-jre">
-	<environment insert="bin/" mode="replace" name="OPENJDK_JRE_BIN"/>
-      </requires>
-      <environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
-      <implementation id="sha1new=6b2afc4b5841dfa24b996b321d08b48109b0c5c3" released="2011-05-29" version="6.18-1.8.7-2">
-	<archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b18-1.8.7-2~squeeze1-1.tar.bz2" size="8887727" type="application/x-bzip-compressed-tar"/>
-      </implementation>
-      <implementation id="sha1new=9af7ae7fa806798b1df663c19cddf97f2aa411ca" released="2009-12-28" version="6.11" version-modifier="-9.1-1">
-	<archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2-1.tar.bz2" size="7610012" type="application/x-bzip-compressed-tar"/>
-      </implementation>
-    </group>
+    <package-implementation main="/usr/bin/javac" package="openjdk-6-jdk"/>
+    <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1_6_0-openjdk-devel"/>
+    <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1.6.0-openjdk-devel"/>
 
-    <group>
-      <requires interface="http://repo.roscidus.com/java/openjdk-jre">
-	<environment insert="bin/java" mode="replace" name="OPENJDK_JRE_JAVA"/>
-      </requires>
-      <implementation id="sha1new=f2da5d5538d0e3b9d9c0843cb9362e900fd33566" released="2009-12-27" version="6.11-9.1">
-	<archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2.tar.bz2" size="7602552" type="application/x-bzip-compressed-tar"/>
-	<environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
-      </implementation>
+    <group main="bin/javac" arch="POSIX-*">
+      <command name="run">
+        <runner interface="http://repo.roscidus.com/java/openjdk-jre"/>
+        <arg>-cp</arg><arg>${JDK_CLASSPATH}</arg>
+        <arg>com.sun.tools.javac.Main</arg>
+      </command>
+
+      <environment insert="lib/sa-jdi.jar" name="JDK_CLASSPATH"/>
+      <environment insert="lib/tools.jar" name="JDK_CLASSPATH"/>
+      <environment insert="lib/jconsole.jar" name="JDK_CLASSPATH"/>
+      <environment insert="lib/dt.jar" name="JDK_CLASSPATH"/>
+
+      <group>
+        <requires interface="http://repo.roscidus.com/java/openjdk-jre">
+	  <environment insert="bin/" mode="replace" name="OPENJDK_JRE_BIN"/>
+        </requires>
+        <environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
+        <implementation id="sha1new=6b2afc4b5841dfa24b996b321d08b48109b0c5c3" released="2011-05-29" version="6.18-1.8.7-2">
+	  <archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b18-1.8.7-2~squeeze1-1.tar.bz2" size="8887727" type="application/x-bzip-compressed-tar"/>
+        </implementation>
+        <implementation id="sha1new=9af7ae7fa806798b1df663c19cddf97f2aa411ca" released="2009-12-28" version="6.11" version-modifier="-9.1-1">
+	  <archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2-1.tar.bz2" size="7610012" type="application/x-bzip-compressed-tar"/>
+        </implementation>
+      </group>
+
+      <group>
+        <requires interface="http://repo.roscidus.com/java/openjdk-jre">
+	  <environment insert="bin/java" mode="replace" name="OPENJDK_JRE_JAVA"/>
+        </requires>
+        <implementation id="sha1new=f2da5d5538d0e3b9d9c0843cb9362e900fd33566" released="2009-12-27" version="6.11-9.1">
+	  <archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2.tar.bz2" size="7602552" type="application/x-bzip-compressed-tar"/>
+	  <environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
+        </implementation>
+      </group>
     </group>
   </group>
 


### PR DESCRIPTION
This is used by tools like Apache Maven, which, when executed on Windows, expect to be executed by a JRE bundled as a part of JDK. On POSIX systems we refer back the regular JRE.
