### PR TITLE
add java-1.8.0-openjdk (RPM) to jre feed

### DIFF
--- a/java/openjdk-jre.xml
+++ b/java/openjdk-jre.xml
@@ -21,6 +21,7 @@
     <package-implementation distributions="Debian" main="/usr/bin/java" package="openjdk-7-jre"/>
     <package-implementation distributions="RPM" main="/usr/bin/java" package="java-1_7_0-openjdk"/>
     <package-implementation distributions="RPM" main="/usr/bin/java" package="java-1.7.0-openjdk"/>
+    <package-implementation distributions="RPM" main="/usr/bin/java" package="java-1.8.0-openjdk"/>
     <package-implementation distributions="Arch" main="/usr/bin/java" package="jre7-openjdk"/>
     <package-implementation distributions="Arch" main="/usr/bin/java" package="jre8-openjdk"/>
 


### PR DESCRIPTION
I notice the feed also has "java-1_7_0-openjdk" (underscores instead of dots). I'm not sure where that is used, but if it's anything more than a historical accident, it should probably be duplicated for 1.8 too.