### PR TITLE
Reflected paths listed in .pth files in feeds

### DIFF
--- a/python/python-gobject.xml
+++ b/python/python-gobject.xml
@@ -45,6 +45,7 @@ the core library used to build GTK+ and GNOME.
       <version before="2.8" not-before="2.7"/>
     </restricts>
     <environment name="PYTHONPATH" insert="." />
+    <environment name="PYTHONPATH" insert="gtk-2.0" />
 
     <implementation version="2.28.3" released="2011-04-10" stability="stable" id="sha1new=dded10ebd18836827f14a9f488346f2c57bd2f4d">
       <manifest-digest sha1new="dded10ebd18836827f14a9f488346f2c57bd2f4d" sha256="34ed5449f429e829cd26b0bafb69b88d8d2a925c38639ebb67e2b5a97293edf9" sha256new="GTWVISPUFHUCTTJGWC5PW2NYRWGSVES4HBRZ5O3H4K22S4UT5X4Q" />

--- a/python/python-gtk.xml
+++ b/python/python-gtk.xml
@@ -19,6 +19,7 @@
     <requires interface="http://repo.roscidus.com/python/python-cairo" />
     <requires interface="http://repo.roscidus.com/python/python-gobject" />
     <environment name="PYTHONPATH" insert="." />
+    <environment name="PYTHONPATH" insert="gtk-2.0" />
 
     <implementation version="2.24.0" released="2011-04-10" stability="stable" id="sha1new=f29642fc00bdfa2a64b443c0a5f94dfb3ed72c99">
       <manifest-digest sha1new="f29642fc00bdfa2a64b443c0a5f94dfb3ed72c99" sha256="eb60285c99026373399e3f33c05d013723fcf63208a21ec4b93ddadd358d43e7" sha256new="5NQCQXEZAJRXGOM6H4Z4AXIBG4R7Z5RSBCRB5RFZHXNN2NMNIPTQ" />

--- a/python/python-win32.xml
+++ b/python/python-win32.xml
@@ -7,8 +7,11 @@
   <homepage>https://sourceforge.net/projects/pywin32/</homepage>
 
   <group license="Python License">
-    <environment name="PYTHONPATH" insert="." />
     <environment name="PATH" insert="pywin32_system32" />
+    <environment name="PYTHONPATH" insert="." />
+    <environment name="PYTHONPATH" insert="win32" />
+    <environment name="PYTHONPATH" insert="win32/lib" />
+    <environment name="PYTHONPATH" insert="pythonwin" />
 
     <group>
       <restricts interface="http://repo.roscidus.com/python/python">


### PR DESCRIPTION
Python does not seem to parse `.pth` files placed outside of the standard `site-packages` directories, even when specified in `PYTHONPATH`.

Therefore I have simply listed the sub-directories usually included by the Python modules using `.pth` files with explicit `<environment name="PYTHONPATH" insert="..." />` entries.