### PR TITLE
Do not set PATH in Git for Windows feed

### DIFF
--- a/git/windows.xml
+++ b/git/windows.xml
@@ -16,8 +16,6 @@
     <requires interface="http://0install.de/feeds/PuTTY.xml">
       <environment insert="plink.exe" mode="replace" name="GIT_SSH"/>
     </requires>
-    <environment insert="cmd" name="PATH"/>
-    <environment insert="usr/bin" name="PATH"/>
     <command name="run" path="cmd/git.exe"/>
     <command name="run-gui" path="cmd/git-gui.exe"/>
     <command name="gitk" path="cmd/gitk.exe"/>

--- a/git/windows.xml.template
+++ b/git/windows.xml.template
@@ -15,8 +15,6 @@
     <requires interface="http://0install.de/feeds/PuTTY.xml">
       <environment name="GIT_SSH" insert="plink.exe" mode="replace"/>
     </requires>
-    <environment name="PATH" insert="cmd"/>
-    <environment name="PATH" insert="usr/bin"/>
     <command name="run" path="cmd/git.exe"/>
     <command name="run-gui" path="cmd/git-gui.exe"/>
     <command name="gitk" path="cmd/gitk.exe"/>


### PR DESCRIPTION
Before this polluted the `PATH` of other feeds that take a dependency on Git with many potentially unwanted entries, for example, `gpg`.
Feeds taking a dependency should explicitly use `<environment/>` or `<executable-in-path/>` instead.