### PR TITLE
Added feed for versioning Docker Compose file format

### DIFF
--- a/docker/compose-format.xml
+++ b/docker/compose-format.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://repo.roscidus.com/docker/compose-format" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Docker Compose file format</name>
+  <summary>empty dependency describing the versioning of the Docker Compose file format</summary>
+  <description>Lists all versions of the Docker Compose file format and their compatibility with specific Docker and Docker Compose versions. Useful to ensure Docker Compose files from different feeds to be merged all share the same file format version and are passed to a suitable Docker (Compose) implementation.</description>
+  <homepage>https://docs.docker.com/compose/compose-file/compose-versioning/</homepage>
+
+  <implementation id="1.0" version="1.0" released="2013-12-20" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="1.9.1.."/>
+  </implementation>
+  <implementation id="2.0" version="2.0" released="2016-01-18" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="1.10.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.6.0-rc1.."/>
+  </implementation>
+  <implementation id="2.1" version="2.1" released="2016-10-20" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="1.12.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.9.0-rc1.."/>
+  </implementation>
+  <implementation id="2.2" version="2.2" released="2017-05-02" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="1.13.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.13.0.."/>
+  </implementation>
+  <implementation id="2.3" version="2.3" released="2017-08-21" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="17.6.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.16.0-rc1.."/>
+  </implementation>
+  <implementation id="3.0" version="3.0" released="2017-01-18" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="1.13.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.10.0.."/>
+  </implementation>
+  <implementation id="3.1" version="3.1" released="2017-02-07" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="1.13.1.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.11.0-rc1.."/>
+  </implementation>
+  <implementation id="3.2" version="3.2" released="2017-03-20" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="17.4.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.12.0-rc1.."/>
+  </implementation>
+  <implementation id="3.3" version="3.3" released="2017-05-31" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="17.6.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.14.0-rc1.."/>
+  </implementation>
+  <implementation id="3.4" version="3.4" released="2017-08-21" stability="stable">
+    <manifest-digest sha1new="da39a3ee5e6b4b0d3255bfef95601890afd80709"/>
+    <recipe/>
+	<restricts interface="http://repo.roscidus.com/docker/client" version="17.6.0.."/>
+	<restricts interface="http://repo.roscidus.com/docker/compose" version="1.16.0-rc1.."/>
+  </implementation>
+</interface>


### PR DESCRIPTION
Lists all versions of the Docker Compose file format and their compatibility with specific Docker and Docker Compose versions. Useful to ensure Docker Compose files from different feeds to be merged all share the same file format version and are passed to a suitable Docker (Compose) implementation.