### PR TITLE
Removed <replaced-by/> tags from old .NET feeds

### DIFF
--- a/cli/cli-monopath.xml
+++ b/cli/cli-monopath.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/cli/cli-monopath" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
-  <name>Common Language Runtime with MONO_PATH support</name>
+  <name>Common Language Runtime with MONO_PATH support (legacy feed)</name>
   <summary>an implementation of the Common Language Runtime (.NET Framework on Windows, Mono on POSIX) using .NET profiles as version numbers</summary>
 
   <feed src="http://repo.roscidus.com/dotnet/clr-monopath" />
-  <replaced-by interface="http://repo.roscidus.com/dotnet/clr-monopath" />
 </interface>

--- a/cli/cli.xml
+++ b/cli/cli.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/cli/cli" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
-  <name>Common Language Runtime</name>
+  <name>Common Language Runtime (legacy feed)</name>
   <summary>an implementation of the Common Language Runtime (.NET Framework on Windows, Mono on POSIX) using .NET profiles as version numbers</summary>
 
   <feed src="http://repo.roscidus.com/dotnet/clr" />
-  <replaced-by interface="http://repo.roscidus.com/dotnet/clr" />
 </interface>

--- a/cli/ironpython.xml
+++ b/cli/ironpython.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/cli/ironpython" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
-  <name>IronPython</name>
+  <name>IronPython (legacy feed)</name>
   <summary>implementation of Python running under .NET/Mono</summary>
   <description>IronPython is an implementation of the Python programming language running under .NET/Mono and Silverlight/Moonlight. It supports an interactive console with fully dynamic compilation. It's well integrated with the rest of the .NET Framework and makes all .NET libraries easily available to Python programmers, while maintaining compatibility with the Python language. There also is Visual Studio tooling integration.</description>
   <homepage>http://ironpython.net/</homepage>
@@ -12,7 +12,6 @@
   <icon href="http://0install.de/feed-icons/IronPython.ico" type="image/vnd.microsoft.icon"/>
 
   <feed src="http://repo.roscidus.com/dotnet/ironpython" />
-  <replaced-by interface="http://repo.roscidus.com/dotnet/ironpython" />
 
   <capabilities xmlns="http://0install.de/schema/desktop-integration/capabilities">
     <file-type id="IronPython.File">

--- a/cli/mono.xml
+++ b/cli/mono.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/cli/mono" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
-  <name>Mono</name>
+  <name>Mono (legacy feed)</name>
   <summary>open-source cross-platform implementation of the Common Language Infrastructure (.NET Framework compatible)</summary>
   <homepage>http://www.mono-project.com/</homepage>
 
   <feed src="http://repo.roscidus.com/dotnet/mono" />
-  <replaced-by interface="http://repo.roscidus.com/dotnet/mono" />
 </interface>

--- a/cli/nant.xml
+++ b/cli/nant.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/cli/nant" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
-  <name>NAnt</name>
+  <name>NAnt (legacy feed)</name>
   <summary>free .NET build tool</summary>
   <description>NAnt is a free .NET build tool. In theory it is kind of like make without make's wrinkles. In practice it's a lot like Ant.</description>
   <icon href="http://0install.de/feed-icons/NAnt.png" type="image/png" />
@@ -11,5 +11,4 @@
   <needs-terminal />
 
   <feed src="http://repo.roscidus.com/dotnet/nant" />
-  <replaced-by interface="http://repo.roscidus.com/dotnet/nant" />
 </interface>

--- a/cli/netfx-client.xml
+++ b/cli/netfx-client.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/cli/netfx-client" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
-  <name>.NET Framework Client Profile</name>
+  <name>.NET Framework Client Profile (legacy feed)</name>
   <summary>a limited version of the .NET Framework from Microsoft</summary>
 
   <feed src="http://repo.roscidus.com/dotnet/framework-client-profile" />
-  <replaced-by interface="http://repo.roscidus.com/dotnet/framework-client-profile" />
 </interface>

--- a/cli/netfx.xml
+++ b/cli/netfx.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/cli/netfx" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
-  <name>.NET Framework</name>
+  <name>.NET Framework (legacy feed)</name>
   <summary>the .NET Framework from Microsoft</summary>
 
   <feed src="http://repo.roscidus.com/dotnet/framework" />
-  <replaced-by interface="http://repo.roscidus.com/dotnet/framework" />
 </interface>


### PR DESCRIPTION
Combing both `<feed/>` and `<replaced-by/>` works only with the Windows version of Zero Install, because it does not implement the `Replaces (and therefore conflicts with) ...` logic.