### PR TITLE
Kubernetes

### DIFF
--- a/kubernetes/kubectl.watch.py
+++ b/kubernetes/kubectl.watch.py
@@ -1,0 +1,12 @@
+from urllib import request
+import json
+
+def convert(release):
+    original_version = release['tag_name'].strip('v')
+    version = original_version.replace('beta.', 'rc').replace('alpha.', 'pre')
+    stability = 'testing' if release['prerelease'] else 'stable'
+    released = release['published_at'][0:10]
+    return {'version': version, 'original-version': original_version, 'stability': stability, 'released': released}
+
+data = request.urlopen('https://api.github.com/repos/kubernetes/kubernetes/releases').read().decode('utf-8')
+releases = [convert(release) for release in json.loads(data)]

--- a/kubernetes/kubectl.xml
+++ b/kubernetes/kubectl.xml
@@ -1,0 +1,619 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/kubernetes/kubectl" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>kubectl</name>
+  <summary>controls the Kubernetes cluster manager</summary>
+  <description>Command-line client that controls the Kubernetes cluster manager.</description>
+  <homepage>https://kubernetes.io/</homepage>
+  <needs-terminal/>
+
+  <group license="Apache License 2.0">
+    <group>
+      <command name="run" path="kubectl"/>
+      <implementation arch="Linux-x86_64" id="sha1new=ca3b6e0875f8e00167b7335976c8512b9a842dcd" released="2017-10-01" stability="stable" version="1.5.8">
+        <manifest-digest sha256new="AZLYO2Z34EGQN4QMGQMXWDL35JAAI65GTAVURCUDKJ7OTMM437TA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.5.8/kubernetes-client-linux-amd64.tar.gz" size="23307092" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=aa65fa1ad2741a2c85ebc07661dc576d13e8a091" released="2017-10-01" stability="stable" version="1.5.8">
+        <manifest-digest sha256new="VS3BUMRWNM3UNVGIED2REUBDSBVAMR2YBRPKOJXA37C4W4PWEXGA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.5.8/kubernetes-client-linux-386.tar.gz" size="22070175" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=9a67b0c2fd38944b9812eaee5fde61fe6b746646" released="2017-10-01" stability="stable" version="1.5.8">
+        <manifest-digest sha256new="SLPA24RNDNZW46XBJJWQ5VRFRUI347ZRXMCEPLGP4JZ6NXGIFPRQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.5.8/kubernetes-client-darwin-amd64.tar.gz" size="23116929" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=f48bbaebb564b35df4ec43a56b654933d83116d4" released="2017-10-25" stability="stable" version="1.6.12">
+        <manifest-digest sha256new="KLYLT75X23YP2JQZL4EKZS3XBW6SJEH4OA4P6WFE4UQZSETQL7IA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.12/kubernetes-client-linux-amd64.tar.gz" size="30417481" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=22fd4316c63f4a397b862d911eb408fc3eda04f5" released="2017-10-25" stability="stable" version="1.6.12">
+        <manifest-digest sha256new="OLQDTDW5FWELJAMMMJ5Y74RTSZJ7QJ2HZUXL4V7HVZQ56OY4TB2A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.12/kubernetes-client-linux-386.tar.gz" size="28977426" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=5bd1a910d971c6c0cad70ea3b3c6d44c2273af29" released="2017-10-25" stability="stable" version="1.6.12">
+        <manifest-digest sha256new="RTQOR5DUHTOC3ARCZY5A3QQY45Q7E3GXG36BMNRYMHMUD7PUTXLA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.12/kubernetes-client-darwin-amd64.tar.gz" size="30169601" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=f95057874c7dea4a0a01d91b1c3454ede2dfe76d" released="2017-11-22" stability="stable" version="1.6.13">
+        <manifest-digest sha256new="JUE2HHPJSHTZSZFFMNWQR22G4NHOU3BKZ6W3AJIHZTHLPPFOSDFQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.13/kubernetes-client-linux-amd64.tar.gz" size="30417473" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=b52f7bf6e2f90923fb725878581b04d8e23a0abc" released="2017-11-22" stability="stable" version="1.6.13">
+        <manifest-digest sha256new="DCU6NPPPH74CPY2KPMRVACS4Y5WUGRXDUECTLYYLIGETJRNP6PBQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.13/kubernetes-client-linux-386.tar.gz" size="28977432" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=40ee685ddcd3f723c2b8a5e57549a9c4fd762bdd" released="2017-11-22" stability="stable" version="1.6.13">
+        <manifest-digest sha256new="TRFQIJGK6VP2MDGVZ4F32NUIJWTIQ22BH6SVSTUDHK5RDXSEKVBQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.13/kubernetes-client-darwin-amd64.tar.gz" size="30169582" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=a8082d6be34606c4373b4aaff9c512ef9b7a936b" released="2017-11-03" stability="stable" version="1.7.10">
+        <manifest-digest sha256new="25E6E2B3CYMG4OZKINOCHMCMFZPRPFLOMJ22Z5KTYM33MGMTLM6Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.10/kubernetes-client-linux-amd64.tar.gz" size="33317474" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=34159a6e16c10cf0360a93ed6abf2ef68f0aae0e" released="2017-11-03" stability="stable" version="1.7.10">
+        <manifest-digest sha256new="X7EWTBR6VFCTSI4QWEC62YSYA7ZBNTWQGPYK5KQ2DXF5VZ6CE2EQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.10/kubernetes-client-linux-386.tar.gz" size="30952825" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=6cef89ff7a0206c897564b32c844e00545ce8d24" released="2017-11-03" stability="stable" version="1.7.10">
+        <manifest-digest sha256new="AOFFIV6B6DWH5ZWHM6IXRCZMHEQN25RWYQDSKBQPSM35ZLBJPDYQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.10/kubernetes-client-darwin-amd64.tar.gz" size="33065977" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=8a7b6b35e25d6051591aa19cac5211f59aa32b7f" released="2017-11-25" stability="stable" version="1.7.11">
+        <manifest-digest sha256new="E4P374UGXGVA3HFAXN7HQMWYPFFWKBVYK3WXQ5YPOJYGHGMTR7OA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.11/kubernetes-client-linux-amd64.tar.gz" size="33317290" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=b45b76d393671bfd9e11a9f1cd42b0c873e65b54" released="2017-11-25" stability="stable" version="1.7.11">
+        <manifest-digest sha256new="RZOD2SA3CJZRF2VD3P7IAGI6ULFPIV236BJY2VZWM5736T2NP57Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.11/kubernetes-client-linux-386.tar.gz" size="30952937" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=37fcdfa9d39be97efc0e89ebcd1fd643e24c39f7" released="2017-11-25" stability="stable" version="1.7.11">
+        <manifest-digest sha256new="5FM4EQXYSMBQ7Z72LOAVKSGG7J6OSVGZWYGZLTNORX2P5FVB5JXQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.11/kubernetes-client-darwin-amd64.tar.gz" size="33066101" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=9d383680a0660a34c0bb8553b7b3e55aa3a4f920" released="2017-12-29" stability="stable" version="1.7.12">
+        <manifest-digest sha256new="DRXJ5K5P3OCMIVBAG5R6ODKX3C774IJ22AJ3P5Q3ANRXPKULANEA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.12/kubernetes-client-linux-amd64.tar.gz" size="33319337" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=cd7e87752d67f55a40e42b68c5afb68c69e01b9c" released="2017-12-29" stability="stable" version="1.7.12">
+        <manifest-digest sha256new="LF6EYQBLAVRALGTTXAAIKG5XM4RCCQRJXNN4GFKN35IUCAFOL42Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.12/kubernetes-client-linux-386.tar.gz" size="30952961" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=29c09d2d04908b976723aa5287f6b9344fcfd56b" released="2017-12-29" stability="stable" version="1.7.12">
+        <manifest-digest sha256new="M4MSLAC3L2GYRUBOHSNFEUVKN6MAOAOKEAISYREWLLXFAPYGEYDQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.12/kubernetes-client-darwin-amd64.tar.gz" size="33066164" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=3f48e8cb7734c2d641f2aa399e2ab8648ba3efed" released="2018-03-01" stability="stable" version="1.7.13">
+        <manifest-digest sha256new="HGYZDLJWXEAO2DUNS3Q7LR2BLE63QS3NRGJLDFWXV3CXUDH47HXA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.13/kubernetes-client-linux-amd64.tar.gz" size="33321384" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=f91a5498ac2066f90d63761ece8924fd91f738ab" released="2018-03-01" stability="stable" version="1.7.13">
+        <manifest-digest sha256new="PLQKEVXLBAYZT6PV2TIV5MNDY2ABBBSO6YFJKUFMNWTOF6V3QFEQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.13/kubernetes-client-linux-386.tar.gz" size="30956891" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=3ea5fe1f5b8f9bfae31e0568e821ba26ae36fed8" released="2018-03-01" stability="stable" version="1.7.13">
+        <manifest-digest sha256new="JH2J4GI4HWY7DVAJHIBB4EJSDUSOI2FWJ35Z7INK23FUZQLZPLEQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.13/kubernetes-client-darwin-amd64.tar.gz" size="33070388" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=088091ce5f6700fb5b4fc839b123480f6190302b" released="2017-10-05" stability="stable" version="1.7.8">
+        <manifest-digest sha256new="ZGQ2RIXFNH52VO3TOSEBT77H5B57WV6T3LR7VUZTPUEKWCH6LDLA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.8/kubernetes-client-linux-amd64.tar.gz" size="33316533" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=fc307b4bb140b5765c7851ea76783b0587bc642e" released="2017-10-05" stability="stable" version="1.7.8">
+        <manifest-digest sha256new="HUQ2Y4J7JJMPVYMVCBFZWTU4IZUHPJLJY7YSZNIY6EEL2BU27KBQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.8/kubernetes-client-linux-386.tar.gz" size="30953910" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=91ff30a89b1b1021ac25b748e800354ef986ee5f" released="2017-10-05" stability="stable" version="1.7.8">
+        <manifest-digest sha256new="NTUWF4ZE3PE2KX3F5HJ6HYJG3HFIFLPAMQWBQX4CCJG7MWKI4DRA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.8/kubernetes-client-darwin-amd64.tar.gz" size="33066403" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=5e0fac5ff260807e340ca54cd4bb81faee5da9f6" released="2017-10-19" stability="stable" version="1.7.9">
+        <manifest-digest sha256new="4CCRHCWGQ6TTTSWF7BH5DGREARXDQYLZHUW3R2AVXYAKA4PFSUVQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.9/kubernetes-client-linux-amd64.tar.gz" size="33316678" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=59b3a3d0beea26d20d7ef3ff27d124679d28ff44" released="2017-10-19" stability="stable" version="1.7.9">
+        <manifest-digest sha256new="FG6DGYF4I336IIPQSMP6KI3V3QXSSU3PNC3OACY2MPC2YUQCCYEA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.9/kubernetes-client-linux-386.tar.gz" size="30954054" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=2e1f7d1e669edb265a5fdb53bbc770186fc44d61" released="2017-10-19" stability="stable" version="1.7.9">
+        <manifest-digest sha256new="3MVL7BPOPSRHVOT6C6WRFBEMLSZCH2WKYZS6B3JCQN5BJJYRIDOA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.9/kubernetes-client-darwin-amd64.tar.gz" size="33066453" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=6cd2d2e386bd053fb6b9fcf44abd37898f25b5a7" released="2017-10-12" stability="stable" version="1.8.1">
+        <manifest-digest sha256new="ADSELZPQAH33DLALL47ADOPQZ4D56GRAGKEIAYIK5XW6D6DQEX7A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.1/kubernetes-client-linux-amd64.tar.gz" size="26123419" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=a4f5c97a9acf21e328636a80ad8e28c908961a8a" released="2017-10-12" stability="stable" version="1.8.1">
+        <manifest-digest sha256new="SSWIASAZTWU4BCSEMNHVSULE5Z6MQVXVNNZPFWGWMH2COTXAUK3A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.1/kubernetes-client-linux-386.tar.gz" size="24354549" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=4c522187b8674e42dce1a64f60299419c29f99ac" released="2017-10-12" stability="stable" version="1.8.1">
+        <manifest-digest sha256new="NOWCLZJMPUMTBMQPSBNVKONGMHDEGMWWHIBZ2XL3RX5SK3Y5JWQA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.1/kubernetes-client-darwin-amd64.tar.gz" size="25929844" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=b4197fbcd7a28d88ff56681999db601f745e67d9" released="2017-10-24" stability="stable" version="1.8.2">
+        <manifest-digest sha256new="PFAM7VK6DDK3KC6ZEVZQ26FCCJHOHMRBSI2U3FDTOB3DWAAKFMUQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.2/kubernetes-client-linux-amd64.tar.gz" size="26125451" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=24234b3d376153b10e516806a9e46bd0bcce701b" released="2017-10-24" stability="stable" version="1.8.2">
+        <manifest-digest sha256new="G42VUNSFBBBXZSAVOWU5ZCFFMLPEHPHEOGIOUH5Q4T5KFRPUA7GQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.2/kubernetes-client-linux-386.tar.gz" size="24355401" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=22f44512ff0c0d3c042c16219bc76ebdfc8d095a" released="2017-10-24" stability="stable" version="1.8.2">
+        <manifest-digest sha256new="NFXHU7RHPVMN6A56UIHROQJSFUQOIXW3DARH3YAEOHDTXCWCY4PA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.2/kubernetes-client-darwin-amd64.tar.gz" size="25929653" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=9336afddb82c9157e18d531107ddcba9bd98059d" released="2017-11-08" stability="stable" version="1.8.3">
+        <manifest-digest sha256new="7QFPUBUZBPBLGWZPZ44XKFY6ZDTZHYSPXNW7EULZMQMM6H2YIN3A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.3/kubernetes-client-linux-amd64.tar.gz" size="26124307" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=214d2428b209006cd7aa5670473ceca8c80b09a9" released="2017-11-08" stability="stable" version="1.8.3">
+        <manifest-digest sha256new="YYBVXYI46UYQ6NWFORFTI4PUPCIAFQA7UHRQR3GO4E4XGOI6WL7A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.3/kubernetes-client-linux-386.tar.gz" size="24354295" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=e0021712352052f77a5c35cacaa2901b3a73b81c" released="2017-11-08" stability="stable" version="1.8.3">
+        <manifest-digest sha256new="W47GM4AXZKHV247J3RK5HVAL2NGVOGQDKG635TWCVL5UW3UWDREQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.3/kubernetes-client-darwin-amd64.tar.gz" size="25929255" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=a99a80938e390483c2df599ae7ecccfd708742a7" released="2017-11-20" stability="stable" version="1.8.4">
+        <manifest-digest sha256new="MNWNYLYEUGR7R5US7QADWMUX2F43QEZPPBWSJT5BX7MCZHHUBE7A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.4/kubernetes-client-linux-amd64.tar.gz" size="26138302" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=e2bdbceb6492d61f5e6bd34dee238cf6b4e94985" released="2017-11-20" stability="stable" version="1.8.4">
+        <manifest-digest sha256new="EK63C37DA4KKVFY77WFMNWDZFXVSH7TI26YIXLU3M2MH6RAO7LWQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.4/kubernetes-client-linux-386.tar.gz" size="24370141" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=8557df91c7b099cd488d2b9b5fc4381cc7dce4af" released="2017-11-20" stability="stable" version="1.8.4">
+        <manifest-digest sha256new="U5I5RUJB4KKGKGOFTQXWLNMJDSZNVDFJRDWJ6RNY5GZ7YLG6MMEQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.4/kubernetes-client-darwin-amd64.tar.gz" size="25941897" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=bf9f5896ac02bffbc15ccf59137ed67a83f3c20e" released="2017-12-07" stability="stable" version="1.8.5">
+        <manifest-digest sha256new="4KMIGRVJ4FFPQ44JVFR4UIADAPHAN6BMIIOSV52DXROVUKTC54ZQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.5/kubernetes-client-linux-amd64.tar.gz" size="26136918" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=83727950ea0257653bd619023ce9403349f1738a" released="2017-12-07" stability="stable" version="1.8.5">
+        <manifest-digest sha256new="QG4Y3M3LD5OLFU7ZZGVN34I376Z5EOYKMJGPYEIEXFVIPQHD2HTA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.5/kubernetes-client-linux-386.tar.gz" size="24367852" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=b0a1be8fc5e03266bc628be4d6126241a538e541" released="2017-12-07" stability="stable" version="1.8.5">
+        <manifest-digest sha256new="ZYFNQJMSD4LO3PNN4MX2B7S76JP7UXEP32OZRHCMOOZ7DJXYU5RA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.5/kubernetes-client-darwin-amd64.tar.gz" size="25942172" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=2a0083f49a44cd2ffb5d12e06811473799fd488a" released="2017-12-21" stability="stable" version="1.8.6">
+        <manifest-digest sha256new="DKIHK4DJ2Q3PFTTAYQX7S77Z2Y65NPFMXCFFQ7C7JU33SPFZMBZA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.6/kubernetes-client-linux-amd64.tar.gz" size="26137695" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=bab0bd9689ccfca8e085cbbe2ee7421d25ca9792" released="2017-12-21" stability="stable" version="1.8.6">
+        <manifest-digest sha256new="KSBNJC7YTBZCFAQLREOHKWQAXSWQMMHVXUCHQ7TDDKZD4MPE7BOA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.6/kubernetes-client-linux-386.tar.gz" size="24368424" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=4f11e5e44f69e081ffcef07c686f20f0646ecb16" released="2017-12-21" stability="stable" version="1.8.6">
+        <manifest-digest sha256new="QRRUJY3VA5M5N7VULSSOU6MWHDRCLCXTKZ2JQEVN3WHTKP3KTZQQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.6/kubernetes-client-darwin-amd64.tar.gz" size="25941409" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=3135441a6df3471b5a65f2ae442a9fe4d41c895a" released="2018-01-17" stability="stable" version="1.8.7">
+        <manifest-digest sha256new="NCDIMWZVRN5VMT4VHGTOOPFWREXDEZW44RILSSIWA46ZIDRRYUSQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.7/kubernetes-client-linux-amd64.tar.gz" size="26148885" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=17ed26de1b10e419f2f21d91f1d0e382b324b7ad" released="2018-01-17" stability="stable" version="1.8.7">
+        <manifest-digest sha256new="P2YZJTWP42AUI7M4HW7NQP7WDIJXHB2IWZZC3COHSELFHRPTFHYQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.7/kubernetes-client-linux-386.tar.gz" size="24373568" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=7306faf66b40ca43c5f03197111d7f8fedc4d602" released="2018-01-17" stability="stable" version="1.8.7">
+        <manifest-digest sha256new="CQV6JTWH2YVIDGFR2TSOVGFABAPWEV44J5IENUKN75AYVKQIIEXA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.7/kubernetes-client-darwin-amd64.tar.gz" size="25953267" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=09d9f594207678fd56b3e74cd63df6adff59ae56" released="2018-02-09" stability="stable" version="1.8.8">
+        <manifest-digest sha256new="Z6TN2DWMNSHTGSEO6HH3473Q6LDOLCSKLNIOEUBFQOAHZBTTUTMA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.8/kubernetes-client-linux-amd64.tar.gz" size="26148749" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=6b66e7c9f36305ca8b0cb49fac60ddf0c8ebfb49" released="2018-02-09" stability="stable" version="1.8.8">
+        <manifest-digest sha256new="6LYZQCHHEEVGHM4K7FX5ZE73OW6PIWO4HKBFSPOQPNAIHQMHPA2Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.8/kubernetes-client-linux-386.tar.gz" size="24378484" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=5063e512ccb070b5335c21763fcf5a34a8980e47" released="2018-02-09" stability="stable" version="1.8.8">
+        <manifest-digest sha256new="4IQ47L64PGZIF5TLS57T4HOG7DT7Q72EBKUWLYFIK7ZSTBI7TTXA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.8/kubernetes-client-darwin-amd64.tar.gz" size="25948922" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=86fb930b4833e386ae27038c0da350608854f314" released="2017-11-01" stability="testing" version="1.9.0-pre2">
+        <manifest-digest sha256new="YPQD7WTEKTRUEXPWXDEEUOP5NSJE7QSVI654IYIYQ3VVWFY4WE7Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.2/kubernetes-client-linux-amd64.tar.gz" size="15315609" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=21369da31f1c421654fde30b70c2f86b3262ae77" released="2017-11-01" stability="testing" version="1.9.0-pre2">
+        <manifest-digest sha256new="ODXIK7D7642YDLOWATTVCVLO5QTGCUAONHOIDWZDODUSHQZA554Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.2/kubernetes-client-linux-386.tar.gz" size="14263866" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=2be7c317b69e61d40e083a57f666abb8f649a3ef" released="2017-11-01" stability="testing" version="1.9.0-pre2">
+        <manifest-digest sha256new="UYPGNKMHPDZZ4H5FN6FJBGTE7WQG6GIDEF7A4NFYKTC5XPS2GZMA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.2/kubernetes-client-darwin-amd64.tar.gz" size="15219231" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=a2ffd5d010e8d7b1268849d10adb35314cf1442b" released="2017-11-16" stability="testing" version="1.9.0-pre3">
+        <manifest-digest sha256new="XN6PUJESUVP66V6K2ZLQCMX6G7NKVCZN35OGSVDGMG5AH3V5MFWQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.3/kubernetes-client-linux-amd64.tar.gz" size="15261705" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=57d9a6da9003728f85804f24535e98f4604b21fa" released="2017-11-16" stability="testing" version="1.9.0-pre3">
+        <manifest-digest sha256new="7KJDOTWLXE5GMNVDGBY4PT36TV6YQHPFMVCBPK2DS4D72Y5IBP4Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.3/kubernetes-client-linux-386.tar.gz" size="14201574" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=3bad9c992d00d0ed812116b98aa847cf2570b4fe" released="2017-11-16" stability="testing" version="1.9.0-pre3">
+        <manifest-digest sha256new="RPAVRRGPTMIOMQ2Y5C2KP7XPDQJJ2PLDCANTJUWN5W5OOCRDOSHQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.3/kubernetes-client-darwin-amd64.tar.gz" size="15162644" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=307dd8c2c9530aa87a5191beea7bedb123fbf1ff" released="2017-11-30" stability="testing" version="1.9.0-rc1">
+        <manifest-digest sha256new="YMEP2R4EIPOW4Z65WR75DMQOZYYRAR7UPLFCYOBVRAVOZATEP6FQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.1/kubernetes-client-linux-amd64.tar.gz" size="15628615" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=e5e1bbd2659b26a986c739c1ffeced4fd69b9f99" released="2017-11-30" stability="testing" version="1.9.0-rc1">
+        <manifest-digest sha256new="K62QOXAR6J4GG6DZA5EEDSRUZIS4R5V5NQLMVVS7BLFK3I2XRFKQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.1/kubernetes-client-linux-386.tar.gz" size="14549207" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=510acc818f3e3e8933b88f536c69c8e3c407ab6e" released="2017-11-30" stability="testing" version="1.9.0-rc1">
+        <manifest-digest sha256new="H426UQNACY5V55MCS7H5YA55XLPIEQ4SFVBNVY7C6LOF5A24HJ2Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.1/kubernetes-client-darwin-amd64.tar.gz" size="15525134" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=2ac73bc9ea6edbf69e7c9b415e0e12cbfc78d7ac" released="2017-12-07" stability="testing" version="1.9.0-rc2">
+        <manifest-digest sha256new="3PS4U2YPDK62BJQ6JUBK7LCV4HTPQL2BYCGGQUZKXBGVPMGKHYYA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.2/kubernetes-client-linux-amd64.tar.gz" size="15629541" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=2a9b7fc92b29b69d962ce8054a749b34f59a5d82" released="2017-12-07" stability="testing" version="1.9.0-rc2">
+        <manifest-digest sha256new="YPFYQOSYIQBLHRD7SC3QID3PQ5DHDM54WCOQJPS26PFL6HK4UR4Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.2/kubernetes-client-linux-386.tar.gz" size="14550528" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=18536f320da25cbd3ae1c4ed24a9d874263dee03" released="2017-12-07" stability="testing" version="1.9.0-rc2">
+        <manifest-digest sha256new="MRGX4JIJKCSDWPKVG3PJ2MQSFMD35SI55YOYIICKOZNKHQXFD4ZA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.2/kubernetes-client-darwin-amd64.tar.gz" size="15526679" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=fef3ca7a395dc7b74f8c9d0df1a976fc06207d09" released="2017-12-15" stability="stable" version="1.9.0">
+        <manifest-digest sha256new="WSTMZZZYRU5NLXZ3II7WFUDCPBQIK3V4PE63Q5WEQTTGLVDY3FYA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0/kubernetes-client-linux-amd64.tar.gz" size="15629107" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=8a8ef1e0d8cbedc6d0a382256a0ad84f3f26f5de" released="2017-12-15" stability="stable" version="1.9.0">
+        <manifest-digest sha256new="NNTEJUE6NSYUY3QQKBSOOGL22ADZMOPL2WUYIS3WJJMUXWSV3PDQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0/kubernetes-client-linux-386.tar.gz" size="14549584" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=2443108dc5520c72fd2fc389a59daf0f58225a69" released="2017-12-15" stability="stable" version="1.9.0">
+        <manifest-digest sha256new="GF3EYJB5EIFLPBXVCA2FWPSVYBPGGOZE5DIWDSD5SOTHP2VUB32Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0/kubernetes-client-darwin-amd64.tar.gz" size="15527032" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=e727e6e18e808cd7c8bd7b4c2c814dc416291212" released="2018-01-04" stability="stable" version="1.9.1">
+        <manifest-digest sha256new="JBUNGWA4MRR2YFIGV2ELO5OCQV4FBPGVSARHULDGQ43ERJ4V7XTA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.1/kubernetes-client-linux-amd64.tar.gz" size="15628786" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=71f9d743885ea6ee769c2400fe84b91d6791aa28" released="2018-01-04" stability="stable" version="1.9.1">
+        <manifest-digest sha256new="ADMIELKHLWHRJXS4ARJOWCGE6NQ4RCEUZVJYFQSCSABDNQ37B37A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.1/kubernetes-client-linux-386.tar.gz" size="14550186" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=cfeb6897f4768246a0ab7a22e22d4b9d252df4e9" released="2018-01-04" stability="stable" version="1.9.1">
+        <manifest-digest sha256new="W6KCGGX3BXCBGUJN4CRYWI263SZO7O4YMM43QBHEPHAUMVYHMZQA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.1/kubernetes-client-darwin-amd64.tar.gz" size="15526736" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=b144e758fcb99d1f9684812980ebd90c7ede6366" released="2018-01-18" stability="stable" version="1.9.2">
+        <manifest-digest sha256new="QQDAUHI7P5KNPV7AQKXEJNOSJFFMFKSXXXDZHQSBMP37EJNHFPGA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.2/kubernetes-client-linux-amd64.tar.gz" size="15628788" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=3f78effc62d9f5f9c5e1c883e14efa327e615c7a" released="2018-01-18" stability="stable" version="1.9.2">
+        <manifest-digest sha256new="LEZCPRZOKCK3E2P3Q7TFBJESRUYXDVKGWUILNHGC7ZN2Q6PDKLKA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.2/kubernetes-client-linux-386.tar.gz" size="14550139" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=4db4bb80344974708b332958d3adcf506a7b6875" released="2018-01-18" stability="stable" version="1.9.2">
+        <manifest-digest sha256new="CHKDBXUXTD5N6A7RPEAWPVPZ42RPSJWGS3RYP74CVTWGHU6F57YQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.2/kubernetes-client-darwin-amd64.tar.gz" size="15526711" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=6c041d61a8427e373ada97a49a7f18c1c8dc58e3" released="2018-02-09" stability="stable" version="1.9.3">
+        <manifest-digest sha256new="PRRCSKPPUNZO2Q5OMKWNBGWQPNOAYLGBOWI7M2JJTUH23X2M5NWQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.3/kubernetes-client-linux-amd64.tar.gz" size="15628384" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=184445380af3d6df4ee7aaa7ec38d2e8fab7c6e5" released="2018-02-09" stability="stable" version="1.9.3">
+        <manifest-digest sha256new="6Z3AWZPZP4DAOWKH5LQWHBCYUST7QVXI6X6TA6S5MU3ERAH6C2ZA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.3/kubernetes-client-linux-386.tar.gz" size="14551377" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=fb9a4ed46c7cb0348ae03331142c510733785907" released="2018-02-09" stability="stable" version="1.9.3">
+        <manifest-digest sha256new="FUXMWPHDY3ESCS4NJLD5XZMESAFUT3NYO3DFWA3QDXKSXZR7ZX6A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.3/kubernetes-client-darwin-amd64.tar.gz" size="15526649" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=0e847806cf9f6d0cea3fdc5c3e5a22295ac7f779" released="2017-12-18" stability="testing" version="1.10.0-pre1">
+        <manifest-digest sha256new="VTLOPFGDWZ65HMVRXC24SI64B2VLYHSIDC5WMRE3ZBTLUS4FOZTA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.1/kubernetes-client-linux-amd64.tar.gz" size="15640109" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=5f442f4a127b428ae9013278133f4962477c71e4" released="2017-12-18" stability="testing" version="1.10.0-pre1">
+        <manifest-digest sha256new="JYDZNMSO3VILFGYSV5CDFC6GGFMLSFITJPUDQOGJDPPN4PS42YPQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.1/kubernetes-client-linux-386.tar.gz" size="14560270" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=254dd662c7e84e109b50b96a8e96c33831378a00" released="2017-12-18" stability="testing" version="1.10.0-pre1">
+        <manifest-digest sha256new="K7EIKKOZZ3NQTQHUXFZQX4V7OUMW2LW7JKELCRBQLU6S4AIZ4UXA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.1/kubernetes-client-darwin-amd64.tar.gz" size="15541281" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=39b7d8d3e7292cfcbc1ddd2cb2138153133a7d7d" released="2018-01-26" stability="testing" version="1.10.0-pre2">
+        <manifest-digest sha256new="MTBQFNUQOMWHFDF7ZOUOFM4A7KQ4TIS7ZJ62K6MYYD5DXCPFZWXQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.2/kubernetes-client-linux-amd64.tar.gz" size="13114675" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=3edb73a32b3fdc4fa95993606cf24a4cc0e95961" released="2018-01-26" stability="testing" version="1.10.0-pre2">
+        <manifest-digest sha256new="ZAFF5WFCJNMPDNITON7VFPXWDOZEHDWOAM4CCL74VVXEAV4DKAPA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.2/kubernetes-client-linux-386.tar.gz" size="12235244" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=9ada0c21ec35206e75ca1f2c2d8ac7f0fcfeb809" released="2018-01-26" stability="testing" version="1.10.0-pre2">
+        <manifest-digest sha256new="K6T3JGWA3WJRPOL33M5Q6O3WRF76ZFC7SLX7KGKIGIPSFKX7BLLA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.2/kubernetes-client-darwin-amd64.tar.gz" size="13034821" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=5ea334e02c0963bea910b14fcd611c1f962be3da" released="2018-02-01" stability="testing" version="1.10.0-pre3">
+        <manifest-digest sha256new="DGNDIXWR773PHAO7O4BF2EUFP6TCGXE3BZWXLIAB75E6MFFQ6RLQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.3/kubernetes-client-linux-amd64.tar.gz" size="13116286" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=c06d3ae3a42a0a97867ffec51394e33053e9b655" released="2018-02-01" stability="testing" version="1.10.0-pre3">
+        <manifest-digest sha256new="VXSISVKRJK5ZWKTTB4QP2CHLUOM7YPXTKQCHWBIPLO7NQYNF52KA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.3/kubernetes-client-linux-386.tar.gz" size="12236467" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=7ea51b5c705640de0b1581101d7281bfffc22b06" released="2018-02-01" stability="testing" version="1.10.0-pre3">
+        <manifest-digest sha256new="6NOBWYK76STKL2RETG2APOVIPYNACTAAF55ZV72QQ7N7FCT5CVTA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.3/kubernetes-client-darwin-amd64.tar.gz" size="13034503" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=25f0c611387831cb21490478100cd2fb5c4ef16b" released="2018-03-01" stability="testing" version="1.10.0-rc1">
+        <manifest-digest sha256new="TNMB3Z6GUPMR2S3UDSRBB4AZJSWHV2DAE6YDEEGOPPTR4VJZB75Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.1/kubernetes-client-linux-amd64.tar.gz" size="13313223" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=0b12ca3b47d80948a020b477afc1d9b2b18f9989" released="2018-03-01" stability="testing" version="1.10.0-rc1">
+        <manifest-digest sha256new="S3K6X2D5AYBDGOY75FF5KYAFUDNVARAVISPU3QOXYG3Z5FGYNJQA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.1/kubernetes-client-linux-386.tar.gz" size="12422659" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=bdd8c5a5a7da3020dd962cf85c698a7aed2322c5" released="2018-03-01" stability="testing" version="1.10.0-rc1">
+        <manifest-digest sha256new="MV3SQ2C5L76YFMWE56S3GUHTCNZHCEI5YY3NZUAIVFK34ZJZFJPA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.1/kubernetes-client-darwin-amd64.tar.gz" size="13233991" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=bc62856084a519196622f3292f04f5ded997e41d" released="2018-03-07" stability="testing" version="1.10.0-rc2">
+        <manifest-digest sha256new="MAZ2XIRCJNBJC3GK2PD45EZ5PPC7BMLXNTZAXZA7QWG5KQBIJ5YA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.2/kubernetes-client-linux-amd64.tar.gz" size="13342513" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=5d1e682a3f7d3f93b008816901b02aa43c6de7f1" released="2018-03-07" stability="testing" version="1.10.0-rc2">
+        <manifest-digest sha256new="LVSON4XTOBV7FIACCQAAH2SYZF22JCNLOEI35PUQUUBYRH66RXXA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.2/kubernetes-client-linux-386.tar.gz" size="12454597" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=b99a76880cf3a2ac19600c5641bbb643ba2721d0" released="2018-03-07" stability="testing" version="1.10.0-rc2">
+        <manifest-digest sha256new="6FVDZ5E52DW2G3BLJMRMBLVHDMLXYPJZOZSTFUUIASJ2GEINA63A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.2/kubernetes-client-darwin-amd64.tar.gz" size="13263358" type="application/x-compressed-tar"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="kubectl.exe"/>
+      <implementation arch="Windows-x86_64" id="sha1new=ede3e3b76172272ca40bce7b5482eae98bf86fe8" released="2017-10-01" stability="stable" version="1.5.8">
+        <manifest-digest sha256new="53SUZQBK47CKNXJAYFXGN67CXORN67I7FDV2KZ7RI2QTYG3USUHQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.5.8/kubernetes-client-windows-amd64.tar.gz" size="23278006" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=24edaebb02259e6b1b767405016d9e5165685457" released="2017-10-01" stability="stable" version="1.5.8">
+        <manifest-digest sha256new="ZEAH6KHDRP5FCXTD34ZWEPG4TVWTOWMNJCHWGH2HYFFVFVFODCTQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.5.8/kubernetes-client-windows-386.tar.gz" size="22055950" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=adf8e2663d3466b599ca70c8025088cbe919b3b8" released="2017-10-25" stability="stable" version="1.6.12">
+        <manifest-digest sha256new="WRKNEOCCZB5SGADLGG2Q7G2OCE3N4AL5DIMKL3P5B3EZ3DIO6X3Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.12/kubernetes-client-windows-amd64.tar.gz" size="30356834" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=f30a2e53e9a6a1a71532b9d7014a01a0b44f20b0" released="2017-10-25" stability="stable" version="1.6.12">
+        <manifest-digest sha256new="C6XT2DVWCCJGETYXQVPZ7GFSQIU3V7HMLB5NGEM5YGYB5JXDOLBA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.12/kubernetes-client-windows-386.tar.gz" size="28929806" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c97065067ace964c023cbf3f8dade263d54ac54e" released="2017-11-22" stability="stable" version="1.6.13">
+        <manifest-digest sha256new="OMB7VABJVJWXJGV6ZG2OG2LWGQH3IL53AABKYO76ITKSKF7CGBPA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.13/kubernetes-client-windows-amd64.tar.gz" size="30357121" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=bb914509b9f89386bbd8171a8d6ccd9ee4ea1e1c" released="2017-11-22" stability="stable" version="1.6.13">
+        <manifest-digest sha256new="7GJPMNKR6YLYEAARRXO46GNFG3JFHJ6IGRGH3K2K7LGSNYBUGZIQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.6.13/kubernetes-client-windows-386.tar.gz" size="28929798" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c1a6b6b4149435bb4bb8cf2ef9e26e8b7a3b77e8" released="2017-11-03" stability="stable" version="1.7.10">
+        <manifest-digest sha256new="CGTUA4URGY6TFRSFOYXAYZKMW7NQ7P23BFUJBRO2FQA5V27ZVQGQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.10/kubernetes-client-windows-amd64.tar.gz" size="33260630" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=dd8944d60fefb1fc7c446a35b2c9b6b74da9b277" released="2017-11-03" stability="stable" version="1.7.10">
+        <manifest-digest sha256new="HWHTINLCCWSTG3L5OC2UCAW2KRIVFKFXOWOEYNRVMUZXFULLTETA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.10/kubernetes-client-windows-386.tar.gz" size="30912982" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=733a2b28cfc4eef945be887e37f77522f63b039d" released="2017-11-25" stability="stable" version="1.7.11">
+        <manifest-digest sha256new="6ULM3YUIA5P6KHTMTZK4UP3UZVX3FSMWTD5IJLIBDYRHROUDZW2A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.11/kubernetes-client-windows-amd64.tar.gz" size="33260634" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=348bc183d07522a8e8351de625715cbed26d8c90" released="2017-11-25" stability="stable" version="1.7.11">
+        <manifest-digest sha256new="6OD6E4A4SQU3UKGBXBYXS57DSQ3SPYLY3ELPTII6S6ULWEUV7MBA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.11/kubernetes-client-windows-386.tar.gz" size="30912831" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=97c8ba5c49cc4916471d52c48b166bbf775b9d6b" released="2017-12-29" stability="stable" version="1.7.12">
+        <manifest-digest sha256new="7MQUULHPOHEOQODC6BXLSBNKC33I4DL32Q2YB3VYCKOETZL7TGHQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.12/kubernetes-client-windows-amd64.tar.gz" size="33266030" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=80d89e0b6cf826396f6d9376c2ef43e66542b879" released="2017-12-29" stability="stable" version="1.7.12">
+        <manifest-digest sha256new="T4YOHCDXNRNFAITUHXSBLZFVCBSAN5USS3IESS4JKRPIFJ2BN2KA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.12/kubernetes-client-windows-386.tar.gz" size="30912436" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=03bcca8c04e8c54b82deeccaaddef5af2705e2e4" released="2018-03-01" stability="stable" version="1.7.13">
+        <manifest-digest sha256new="UZ5ZQMYWM3UDATTGTYC5QQXS45BRWANJQGH5DYWJIHIIKXSQ26NQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.13/kubernetes-client-windows-amd64.tar.gz" size="33271022" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=ab65e502d1e6afae6535b81446e6097cbcb2c8de" released="2018-03-01" stability="stable" version="1.7.13">
+        <manifest-digest sha256new="TYGMMDEPGBTGVCCRA6PSABNBNRBHWYPEYLCWZRKGDH2FHD7KJEAQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.13/kubernetes-client-windows-386.tar.gz" size="30913683" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=02c08eaa2437a569e45b29139f63643a7aa87170" released="2017-10-05" stability="stable" version="1.7.8">
+        <manifest-digest sha256new="WDDW7WIM3BNABQL7HFYZ3IBSSZJ3E3OHLPJNGK7R7A5BQAF7H7EA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.8/kubernetes-client-windows-amd64.tar.gz" size="33270966" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=717963148475f239c82efe9b5be3d63a522fbbf1" released="2017-10-05" stability="stable" version="1.7.8">
+        <manifest-digest sha256new="45YK6QT2Y2S7MFWZZ7JZ6GVZQPXJ7YZA5EXRX7QFE5XDLUWBKEBQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.8/kubernetes-client-windows-386.tar.gz" size="30913824" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=eca5fc4e84ea3f74ca815d54226e83e28bb99632" released="2017-10-19" stability="stable" version="1.7.9">
+        <manifest-digest sha256new="HAT27ELYQW54AEC6VZSHEGIT5Z6CEQSMBSRL6DA6WEUVOI4BW36Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.9/kubernetes-client-windows-amd64.tar.gz" size="33271234" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=f38787ab6c4e7133ab4f1caab44b751ba3c5f945" released="2017-10-19" stability="stable" version="1.7.9">
+        <manifest-digest sha256new="I2FOZA6KCEDCPXU4SS2AWF5MEU64F3XLSHIG4PMUYPVMO3WWSTPQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.7.9/kubernetes-client-windows-386.tar.gz" size="30913978" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=adb09400f601a2fb843fc00b305aa8a1e1380f7c" released="2017-10-12" stability="stable" version="1.8.1">
+        <manifest-digest sha256new="OOP5T2553MDMHR2VNMHHRNZ6EOKGEI3CQABH6IW4LLAQ2QFN4VWQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.1/kubernetes-client-windows-amd64.tar.gz" size="26163244" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=f5b71482b4a6ea2e6e44d37a0aa7e84479b0710c" released="2017-10-12" stability="stable" version="1.8.1">
+        <manifest-digest sha256new="UYVWKX5CI4PMH2J4J427ZKO7ZAREUJORYGBD24BUPVXZ6UMADGUA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.1/kubernetes-client-windows-386.tar.gz" size="24385475" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=8ff1ccd4a56b6fed4c937e19bcaa6aaef876b84a" released="2017-10-24" stability="stable" version="1.8.2">
+        <manifest-digest sha256new="CTQD7GFGONI2HB55ZXPQSWX5VI6X5YA45ANOSD4PE4LX6F67AMQA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.2/kubernetes-client-windows-amd64.tar.gz" size="26163494" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=ce669d3df6cc24afea4b93fa24a39e898dcaa3df" released="2017-10-24" stability="stable" version="1.8.2">
+        <manifest-digest sha256new="54AIXOFLHV64DHCU54ZPENX26ETGZ4LAJB3GPMUTCD3ZWBR2I3YA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.2/kubernetes-client-windows-386.tar.gz" size="24388611" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=f8de83e2dc4fa414ca306bd828bd3edbd821a393" released="2017-11-08" stability="stable" version="1.8.3">
+        <manifest-digest sha256new="BU2ILYCX6YXEZMNS6MW7IAORKIU2RCFE5TPCKJOD7OIAL2BRSTCA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.3/kubernetes-client-windows-amd64.tar.gz" size="26162663" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=63b8ba142ae0ce68de4d8d2d221336935381502d" released="2017-11-08" stability="stable" version="1.8.3">
+        <manifest-digest sha256new="GNI2JMQ2URVBENPHR2ZFOCPLYMLZXFTEY2IDGHO77CXY6YBABZTA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.3/kubernetes-client-windows-386.tar.gz" size="24386193" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=13354c67ad807302127ba53831dd17e22f6db03a" released="2017-11-20" stability="stable" version="1.8.4">
+        <manifest-digest sha256new="G6HLJIQJC4KHABB7GFRI5W3S6RENUA3AWYRCBKMD75JECVZAAAUQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.4/kubernetes-client-windows-amd64.tar.gz" size="26175752" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=8b97652d9aa3671c249f146775c665f06aabd696" released="2017-11-20" stability="stable" version="1.8.4">
+        <manifest-digest sha256new="LUQULZWNHXY4ULMI5KPULW77HD6E6MGDSSYDCZKHEWWUBDC4OLKA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.4/kubernetes-client-windows-386.tar.gz" size="24397971" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=29306963b5318b458c3ddd2d47053d2e3e5b3958" released="2017-12-07" stability="stable" version="1.8.5">
+        <manifest-digest sha256new="RA22ZF6BLHFQUI62TWMESAQFSNYFWCAKB5FLRFMQVEXNAOCUFYLQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.5/kubernetes-client-windows-amd64.tar.gz" size="26177188" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=7fb835979f55198ee8a9b4463d7526e3c0649fd0" released="2017-12-07" stability="stable" version="1.8.5">
+        <manifest-digest sha256new="R6QYSFAGFD3A5SGGJAIPOLMASDG47E32Y7IHREPH3DZEUIG5HW5A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.5/kubernetes-client-windows-386.tar.gz" size="24394177" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=33ce3f5631ec310b1df121017b921150e83157eb" released="2017-12-21" stability="stable" version="1.8.6">
+        <manifest-digest sha256new="3YPJT7F25J4MQGRRBNVFT4BQ4DYZWIXHCJZMEUSHHJJFJKUEWKEA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.6/kubernetes-client-windows-amd64.tar.gz" size="26177629" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=dbc2a97ba64fcb561798b85ddaaf93db3849a9a4" released="2017-12-21" stability="stable" version="1.8.6">
+        <manifest-digest sha256new="PV7O6AVFB7DY2BEV6F3TDTS46EO46JEM4DLOVYIY227GVU3WZAZQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.6/kubernetes-client-windows-386.tar.gz" size="24393566" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=ea4aa2c4694558cf77572037d198051b8d09fe00" released="2018-01-17" stability="stable" version="1.8.7">
+        <manifest-digest sha256new="42DJFFRPFVCMCB6F5FICLJGCJENDZ2CWNNGZPZAEKBS7MXGQPQ6A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.7/kubernetes-client-windows-amd64.tar.gz" size="26187300" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=a7712c35665a300c8df4353301a660b68f969edd" released="2018-01-17" stability="stable" version="1.8.7">
+        <manifest-digest sha256new="57QL4LLGXKJ7MGMVWUOK7FKD2HSZ2N4TLYYWLBOMLRMRTBXTVT3A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.7/kubernetes-client-windows-386.tar.gz" size="24406234" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c6239ae75a378da0471cbd83c124b018919d76de" released="2018-02-09" stability="stable" version="1.8.8">
+        <manifest-digest sha256new="3BA42U3QTXBCCJ5MK323OSTACRAN2SCL34JLJFEUFKVNLN776VPQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.8/kubernetes-client-windows-amd64.tar.gz" size="26193087" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=7b729509f02e15a68c08aaeb4651772e23a683fc" released="2018-02-09" stability="stable" version="1.8.8">
+        <manifest-digest sha256new="BCP66SBWI77SCUKXOA7TGL5SGX7TLI56AUUG4Q43A5R3PQRNGC5A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.8.8/kubernetes-client-windows-386.tar.gz" size="24405361" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=3b66d32d12c33cc6350a36b19471d3141fedd168" released="2017-11-01" stability="testing" version="1.9.0-pre2">
+        <manifest-digest sha256new="ZWDJH5SFHURYHEQODZYEWXZIJBM7TZR4I2S322N6HWM7JC3XAJYQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.2/kubernetes-client-windows-amd64.tar.gz" size="15357969" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=8b7dbdc41599b41a7badc4106bc2bd7bddd0a07a" released="2017-11-01" stability="testing" version="1.9.0-pre2">
+        <manifest-digest sha256new="L2MSA3DG7OTJEIK5OIS7IKAHIHFIT22DLFA7CJ3UXYTOAJ3DU7BQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.2/kubernetes-client-windows-386.tar.gz" size="14275317" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=bdc79d3db1a713d10eed6c7a9cc0b661c9c9c4fc" released="2017-11-16" stability="testing" version="1.9.0-pre3">
+        <manifest-digest sha256new="S7OA7W5GVCWBHLS433DA7GTVZHGA34Q4N6FQUMKYNMVXXIS2UMYA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.3/kubernetes-client-windows-amd64.tar.gz" size="15302311" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=2a2b5b2f4d2a5728db726978b4ee523064699c30" released="2017-11-16" stability="testing" version="1.9.0-pre3">
+        <manifest-digest sha256new="DMKZYUB5WX3YMKMW3EDSJIV6DGTPCR7BUL57JLV4FTK4WGZ4CC6Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-alpha.3/kubernetes-client-windows-386.tar.gz" size="14217930" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=f143d8a23af28f29579b0974373ba2f0f59e857c" released="2017-11-30" stability="testing" version="1.9.0-rc1">
+        <manifest-digest sha256new="TURZASXOLIAJCGP4CRMWCW6T2DQ6CBLYNPARBV3KIT36QH7XNB7A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.1/kubernetes-client-windows-amd64.tar.gz" size="15665730" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=65f27f40250b3d3767a9845b9bb1a1d33981ddf7" released="2017-11-30" stability="testing" version="1.9.0-rc1">
+        <manifest-digest sha256new="PKQAWLNUIHXRC7X6L5KO5UHPPTNOUKOYAJGQJIFBJGAL6K47MWEA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.1/kubernetes-client-windows-386.tar.gz" size="14562938" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=a597b0ae684d9bf36e94911a7820ace244c42850" released="2017-12-07" stability="testing" version="1.9.0-rc2">
+        <manifest-digest sha256new="KCI5DUOIHY27OVAHUWGWEVU4MXV5RDVRYIPP7OCKQ2XFJO6AA4VQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.2/kubernetes-client-windows-amd64.tar.gz" size="15665087" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=0cf895c817247b68af6f8cd1ac5d3b2e9c5d404f" released="2017-12-07" stability="testing" version="1.9.0-rc2">
+        <manifest-digest sha256new="QZNDT2GJM2LGWAOX3AKL2MNN5DUPMTW7F4H7DUJSJDHTKCNTWGMA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0-beta.2/kubernetes-client-windows-386.tar.gz" size="14563025" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=065fa0bab468f4ad8a7041959160cbe9448573dc" released="2017-12-15" stability="stable" version="1.9.0">
+        <manifest-digest sha256new="JOKSZ6LSSVFJ6WKC7NX6A6GVQ7D6DKDHGU6QGJ32MD2GY6J42VGA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0/kubernetes-client-windows-amd64.tar.gz" size="15666769" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=9e0980c7f8fe61254362de6c297f78a265d2f1cf" released="2017-12-15" stability="stable" version="1.9.0">
+        <manifest-digest sha256new="RD3LYVIUJ6VGJSYE2HEM5DWF6ZSHDTCCOQ5GNWWLQQI2D44IRTUA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.0/kubernetes-client-windows-386.tar.gz" size="14562813" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=590a30fd6b0078839a6e8283b63c819d52a0cd0b" released="2018-01-04" stability="stable" version="1.9.1">
+        <manifest-digest sha256new="XIW25XDPJKRLKLSATA24OMNRQY67TLNHT7HMFSJZ5ARJ5A26ZWAA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.1/kubernetes-client-windows-amd64.tar.gz" size="15665855" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=420f9a643163e2ad22772331bbd5540eafeb54de" released="2018-01-04" stability="stable" version="1.9.1">
+        <manifest-digest sha256new="VNIWBPFNQJV45MSHB3RN4O6ZTLNTBHCW3ZGA2MHX3DXFCTVYWCUQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.1/kubernetes-client-windows-386.tar.gz" size="14564330" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=393bdf5934f7e1fe9212fbbc7786cc2acd946277" released="2018-01-18" stability="stable" version="1.9.2">
+        <manifest-digest sha256new="7OQBSMUSYX3M6TMY4DFZHOAQCKBHSPOYQUXMVY5K3OCNLGQZLBSA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.2/kubernetes-client-windows-amd64.tar.gz" size="15665829" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=bbd7761b1296ac09f1743ae0da4ee1907a0f1573" released="2018-01-18" stability="stable" version="1.9.2">
+        <manifest-digest sha256new="CMH554KBTZSZHW6B4SBPOQOU2YVJIYFYOA7C2I25P7W6Q2UCSR7Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.2/kubernetes-client-windows-386.tar.gz" size="14564334" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=f33f79c09819c1a5f54c70f097040fe397381619" released="2018-02-09" stability="stable" version="1.9.3">
+        <manifest-digest sha256new="E6KAUNUWMGJDDSHFWCBYCQXIH2HVE6MYQCNPUOJDDAZVR637LJNQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.3/kubernetes-client-windows-amd64.tar.gz" size="15667636" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=ce14701f303320e4a8574304b9a4c259f0f1f275" released="2018-02-09" stability="stable" version="1.9.3">
+        <manifest-digest sha256new="MUNCDQPNV4FPIXLRKNJI6I7KQXKII3FJBOABWPVDEZET7VYY7KBQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.9.3/kubernetes-client-windows-386.tar.gz" size="14564306" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=e8eb5fa8691875de5f69a03f4376d4bf82cc8aff" released="2017-12-18" stability="testing" version="1.10.0-pre1">
+        <manifest-digest sha256new="Z7KGSIPATXVETKJ3GBN43MPGVNU6MQCD6FMEDWPFKG7WYHHFECKA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.1/kubernetes-client-windows-amd64.tar.gz" size="15681562" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=ba2c8a1d6dddbe212baf9f9d4e66de3ba33e3776" released="2017-12-18" stability="testing" version="1.10.0-pre1">
+        <manifest-digest sha256new="QPDC34SLIRO53WYB2GL7L2XGVB2WSNRO2B7IARS5ECBNM6RVN6LQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.1/kubernetes-client-windows-386.tar.gz" size="14574036" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=bf3235c2e173581c524298f3a67f0b41dcd8fa22" released="2018-01-26" stability="testing" version="1.10.0-pre2">
+        <manifest-digest sha256new="RFAUWSGPVAOCW67WO3KDO4MWKYGOQITPKTTF6MNDSCCBCZSGNI4A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.2/kubernetes-client-windows-amd64.tar.gz" size="13171605" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=dcbcd67e5a4e1e9ff5a2310d3e4b36ffc0398abf" released="2018-01-26" stability="testing" version="1.10.0-pre2">
+        <manifest-digest sha256new="ZYRXBTEWWQDFUN5DKOOKRM6C2K22SLLCOYSUP42LZEMFWBKRSA3A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.2/kubernetes-client-windows-386.tar.gz" size="12271235" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=4a404ed774c4ba1dda6d58353d4f4eb08df002bb" released="2018-02-01" stability="testing" version="1.10.0-pre3">
+        <manifest-digest sha256new="WL6EJAFCMUJAPOVJYV3AZRQUS427MWKAOZPDMPQO7WBLFBNADS5Q"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.3/kubernetes-client-windows-amd64.tar.gz" size="13174217" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=1330e45751ad44eb1fd6272b8f6c4ff3e883aa5d" released="2018-02-01" stability="testing" version="1.10.0-pre3">
+        <manifest-digest sha256new="YVXFDH4S3MGGKN2S4U3CKI37GVLYE6XVU4ZFYFXK5WLJOZE3RSBA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-alpha.3/kubernetes-client-windows-386.tar.gz" size="12271590" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=81c0191391768cd9b9b63110f42f9d2f584c4010" released="2018-03-01" stability="testing" version="1.10.0-rc1">
+        <manifest-digest sha256new="PQ2DZA4NO7OM3NWWC5OXCUSHZPWVSZEZINUVH73ICOJYISZ22MPQ"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.1/kubernetes-client-windows-amd64.tar.gz" size="13367679" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=07c739dbdb488a873e69258b625f6fba7a6d01da" released="2018-03-01" stability="testing" version="1.10.0-rc1">
+        <manifest-digest sha256new="XTAF7O5MB4RVLBQLZNTFGAKQNBAANAVY35RKH7RX7SWLOKE7Q4DA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.1/kubernetes-client-windows-386.tar.gz" size="12455488" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=40b705f4f3665c8400886f3c23ad599c84bc21cb" released="2018-03-07" stability="testing" version="1.10.0-rc2">
+        <manifest-digest sha256new="SUQDVR76IXZMR7HLDRSB2TGH3DI3RAAXN57QEZ7GAMMXT6CMXL7A"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.2/kubernetes-client-windows-amd64.tar.gz" size="13398599" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=f01f84d986e99729dd88e0dbb632e76811a5cf49" released="2018-03-07" stability="testing" version="1.10.0-rc2">
+        <manifest-digest sha256new="R6NZLDADDUB5IZQFA4FHI6SO6X35BQMODBEDYFRKKMDM6YAWLYDA"/>
+        <archive extract="kubernetes/client/bin" href="https://dl.k8s.io/v1.10.0-beta.2/kubernetes-client-windows-386.tar.gz" size="12485359" type="application/x-compressed-tar"/>
+      </implementation>
+    </group>
+  </group>
+
+  <entry-point binary-name="kubectl" command="run"/>
+</interface>

--- a/kubernetes/kubectl.xml.template
+++ b/kubernetes/kubectl.xml.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>kubectl</name>
+  <summary>controls the Kubernetes cluster manager</summary>
+  <description>Command-line client that controls the Kubernetes cluster manager.</description>
+  <homepage>https://kubernetes.io/</homepage>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/kubernetes/kubectl"/>
+
+  <group license="Apache License 2.0">
+    <group>
+      <command name="run" path="kubectl"/>
+      <implementation arch="Linux-x86_64" version="{version}" stability="{stability}" released="{released}">
+        <manifest-digest/>
+        <archive href="https://dl.k8s.io/v{original-version}/kubernetes-client-linux-amd64.tar.gz" type="application/x-compressed-tar" extract="kubernetes/client/bin"/>
+      </implementation>
+      <implementation arch="Linux-i486" version="{version}" stability="{stability}" released="{released}">
+        <manifest-digest/>
+        <archive href="https://dl.k8s.io/v{original-version}/kubernetes-client-linux-386.tar.gz" type="application/x-compressed-tar" extract="kubernetes/client/bin"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" version="{version}" stability="{stability}" released="{released}">
+        <manifest-digest/>
+        <archive href="https://dl.k8s.io/v{original-version}/kubernetes-client-darwin-amd64.tar.gz" type="application/x-compressed-tar" extract="kubernetes/client/bin"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="kubectl.exe"/>
+      <implementation arch="Windows-x86_64" version="{version}" stability="{stability}" released="{released}">
+        <manifest-digest/>
+        <archive href="https://dl.k8s.io/v{original-version}/kubernetes-client-windows-amd64.tar.gz" type="application/x-compressed-tar" extract="kubernetes/client/bin"/>
+      </implementation>
+      <implementation arch="Windows-i486" version="{version}" stability="{stability}" released="{released}">
+        <manifest-digest/>
+        <archive href="https://dl.k8s.io/v{original-version}/kubernetes-client-windows-386.tar.gz" type="application/x-compressed-tar" extract="kubernetes/client/bin"/>
+      </implementation>
+    </group>
+  </group>
+</interface>


### PR DESCRIPTION
This adds a feed for Kubernetes' `kubectl`.

Here is an `index.html` for the new `kubernetes/` directory:
```html
<!DOCTYPE html>
<html>
  <head>
    <title>repo.roscidus.com: Kubernetes</title>
  </head>
  <body>
    <h1>repo.roscidus.com: Kubernetes</h1>
    <p>
      Kubernetes is an open source system for managing containerized applications across multiple hosts.
    </p>

    <p>To add the Kubernetes client CLI to your <code>PATH</code>:</p>
    <pre>
      $ 0alias kubectl http://repo.roscidus.com/kubernetes/kubectl
    </pre>

    <h2>Available feeds</h2>

    <ul>
      <li><a href='kubectl'>kubectl</a></li>
    </ul>
  </body>
</html>
```