### PR TITLE
Updated cURL

### DIFF
--- a/utils/curl.watch.py
+++ b/utils/curl.watch.py
@@ -1,8 +1,0 @@
-from urllib import request
-import re
-
-excluded_versions = ['7.52.0', '7.54.1', '7.55.0', '7.56.1']
-
-data = request.urlopen('https://dl.uxnr.de/build/curl/curl_winssl_msys2_mingw64_stc/').read().decode('utf-8')
-matches = re.findall(r'curl-([0-9\.]+)\/<\/a><\/td><td align="right">(....-..-..)', data)
-releases = [{'version': match[0], 'released': match[1]} for match in matches if not match[0] in excluded_versions]

--- a/utils/curl.xml
+++ b/utils/curl.xml
@@ -131,6 +131,14 @@
       <manifest-digest sha256new="QJ7DREAQCZLCYJCLLT7VT6TI27YFUMTSJ5GRFZCO4HVKXP27DFUA"/>
       <archive extract="src" href="https://dl.uxnr.de/build/curl/curl_winssl_msys2_mingw32_stc/curl-7.59.0/curl-7.59.0.zip" size="1743057" type="application/zip"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=98bf5772af47b4e0d24bf34483e89076dc87e608" released="2018-05-17" version="7.60.0" stability="stable">
+      <manifest-digest sha256new="2XYXIHKQPOKZNNQI2PHNAOP5SYU5JTLRMKAAIXPCRSWPDVKU7RVA"/>
+      <archive extract="curl-7.60.0-win64-mingw" href="curl-7.60.0-win64-mingw.zip" size="3085371" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=42d3ca7c00d2e8f10aca731d8c48dc38b3a4d833" released="2018-05-17" version="7.60.0" stability="stable">
+      <manifest-digest sha256new="7BJJA7P7WT6KVWLGJFS5VIIPW3WUF6ZHBORHHYJ5CKW76IM3ALTA"/>
+      <archive extract="curl-7.60.0-win32-mingw" href="curl-7.60.0-win32-mingw.zip" size="2844331" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="curl" command="run"/>

--- a/utils/curl.xml.template
+++ b/utils/curl.xml.template
@@ -21,11 +21,11 @@
   <group license="MIT License" main="curl.exe">
     <implementation arch="Windows-x86_64" version="{version}" released="{released}" stability="stable">
       <manifest-digest/>
-      <archive href="https://dl.uxnr.de/build/curl/curl_winssl_msys2_mingw64_stc/curl-{version}/curl-{version}.zip" extract="src" type="application/zip"/>
+      <archive href="curl-{version}-win64-mingw.zip" extract="curl-{version}-win64-mingw" type="application/zip"/>
     </implementation>
     <implementation arch="Windows-i486" version="{version}" released="{released}" stability="stable">
       <manifest-digest/>
-      <archive href="https://dl.uxnr.de/build/curl/curl_winssl_msys2_mingw32_stc/curl-{version}/curl-{version}.zip" extract="src" type="application/zip"/>
+      <archive href="curl-{version}-win32-mingw.zip" extract="curl-{version}-win32-mingw" type="application/zip"/>
     </implementation>
   </group>
 </interface>


### PR DESCRIPTION
This pull request requires the following files to be placed in `incoming/`:
- [curl-7.60.0-win32-mingw.zip](https://github.com/0install/repo.roscidus.com/files/2035532/curl-7.60.0-win32-mingw.zip)
- [curl-7.60.0-win64-mingw.zip](https://github.com/0install/repo.roscidus.com/files/2035533/curl-7.60.0-win64-mingw.zip)

I got these files by downloading the [Chocolatey cURL package](https://chocolatey.org/packages/curl) (as linked to by [cURL's official download page](https://curl.haxx.se/download.html)) and extracting it.