### PR TITLE
Hashicorp feeds (Vagrant, Terraform, Packer)

### DIFF
--- a/hashicorp/packer.watch.py
+++ b/hashicorp/packer.watch.py
@@ -1,0 +1,5 @@
+from urllib import request
+import json
+
+data = request.urlopen('https://api.github.com/repos/hashicorp/packer/tags').read().decode('utf-8')
+releases = [{'version': tag['name'].strip('v')} for tag in json.loads(data) if not '-' in tag['name']]

--- a/hashicorp/packer.xml
+++ b/hashicorp/packer.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/hashicorp/packer" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Packer</name>
+  <summary>build automated machine images</summary>
+  <description>Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.</description>
+  <homepage>https://www.packer.io/</homepage>
+  <needs-terminal/>
+
+  <group license="Mozilla Public License 2.0">
+    <group>
+      <command name="run" path="packer"/>
+      <implementation arch="Linux-x86_64" id="sha1new=23f2d05bbd8355b519181b63b681a3b91f502582" released="2018-06-14" stability="stable" version="0.8.3">
+        <manifest-digest sha256new="ZKZMEQEW52FFX5C2OWKDS774GRPG6ZVTEAYMEG37IMNUUIKTGV7Q"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.3/packer_0.8.3_linux_amd64.zip" size="118496644" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=c9e1652ff6ff5f3df4a9a02df74035df0f577c44" released="2018-06-14" stability="stable" version="0.8.3">
+        <manifest-digest sha256new="SJ3PVWXKXRUMOG5AFPJUVTQJ6LUYPVZO2IMWACO4BLY5QLEN75PQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.3/packer_0.8.3_darwin_amd64.zip" size="118228371" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=69c1a33fb286186a93677b43e57765ddbead275c" released="2018-06-14" stability="stable" version="0.8.5">
+        <manifest-digest sha256new="AKPDHVEJMMQL7ZBESIESB57E4DM3O3MNEFSDHMKANP3NVJM7WUVA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.5/packer_0.8.5_linux_amd64.zip" size="118513002" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=833181138b61ffa2606775ceb1ae0de6dc65455d" released="2018-06-14" stability="stable" version="0.8.5">
+        <manifest-digest sha256new="JXJGOBZ4ZDVMZHZQQF7VQJ4IPU5GMZW7OTAL2CLMCQHUTHFDYNDA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.5/packer_0.8.5_darwin_amd64.zip" size="118246892" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=69f05a65c4ce2a2c9af1de98899f2a142c4da556" released="2018-06-14" stability="stable" version="0.8.6">
+        <manifest-digest sha256new="KQZOAVSTSMDNXK7MEFDIUCGW5RU7SWAUH563JOJ7OKEWFCPCD3AA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip" size="132616691" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=ab652b0f4157b7506365afc9e89fa2e746b51397" released="2018-06-14" stability="stable" version="0.8.6">
+        <manifest-digest sha256new="LYMDRBFK2AT7RLAS5RTMAHXRA2RTA56IUWJEDCWAS3I4R43I4IGQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_darwin_amd64.zip" size="131918453" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=f7337d72736d81f944a31a8ac53c80030b96e93f" released="2018-06-14" stability="stable" version="0.9.0">
+        <manifest-digest sha256new="LE2MYYM37XWSEO2Z7JKDWBPK2TU4T7EWIPN3RKNNRBWTNGXHP5SQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.9.0/packer_0.9.0_linux_amd64.zip" size="8317265" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=d9ff7893535fdd0f0762506fd228964663693ce9" released="2018-06-14" stability="stable" version="0.9.0">
+        <manifest-digest sha256new="NKOCAHB7NPYWBWPCCE7Q5AWXGW2UXQX3L34OMPRGJU36FBE7KFVA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.9.0/packer_0.9.0_darwin_amd64.zip" size="8274465" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=c1e3bd6c5be5a52bbd7804ce6e68eaf7a93d539c" released="2018-06-14" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="JR5SMXOKAZ75I5C3FZFF55VQWNEO2MRNH466IGMOXYJTPHSX4CVA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.0/packer_0.10.0_linux_amd64.zip" size="8821665" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=794fc9a6f06cbbe2f3352e928daf3be313719ede" released="2018-06-14" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="NF4L4GEXMAFYQK6KOD437XHL3C5MXYKUYLJ2APLJURF2VYLVTUYA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.0/packer_0.10.0_darwin_amd64.zip" size="8771487" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=6e61c54a772135bca1d9f5b6134d9dd20d9184ec" released="2018-06-14" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="GAXEMGOZJUKCRGZMVEL6WBWPG3XB5PDYPKHKPOZ6GZAD3MVEJRVA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.1/packer_0.10.1_linux_amd64.zip" size="8985735" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=bfc4a0cb6bc3e0c034bdb78ce2651b6990067f66" released="2018-06-14" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="JP5TCPDPNSNCYXMROEFP62RAB6XP2ZVWWZPF4AK5FMHBK6FDKEXQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.1/packer_0.10.1_darwin_amd64.zip" size="8934353" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=3c3df25339f227a04bbe86e98968fbace4b4f34d" released="2018-06-14" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="6KPMJXHHVZUKBXELTC3TAMWGMWITV3JUULVTH75SYQ3XYPYNFF4A"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_linux_amd64.zip" size="8020298" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=5e38ddfb5ed6a72837cb87b47c126aa7f2f9b4df" released="2018-06-14" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="QK555NW6R7LTEDQ5PDPV3N5SPV44UD6T2O3CKBVTNRI5MR3UMSOQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_darwin_amd64.zip" size="7997225" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=fa1973e8b3d2426b567b507b94633c9a751f4b82" released="2018-06-14" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="UXEBEGWOSXZ2UZ7REFQAGBCSYUA3TEHBCFCXZX2C2GX2LFISHBVA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.11.0/packer_0.11.0_linux_amd64.zip" size="8524906" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=12fab1303ae024ce8099bee4cbb5af9e4c85a3cd" released="2018-06-14" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="5HX5C6PYDATQPTOPM7O3X2ANRXITO6VB63HL47BTPQGUELTOPICQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.11.0/packer_0.11.0_darwin_amd64.zip" size="8501648" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=ecf540b1730e8b0f4ced88a665861189039c6005" released="2018-06-14" stability="stable" version="0.12.0">
+        <manifest-digest sha256new="2XGPVO36AQITI7AHRLNN3K2X4R43RNNFLYG3DXOO2SW3RQUWHWRQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.0/packer_0.12.0_linux_amd64.zip" size="10047746" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=5211ddfd70d331fd6822b38c64f4de2bb7221183" released="2018-06-14" stability="stable" version="0.12.0">
+        <manifest-digest sha256new="ZV56NZJXJPSPZJ3XUGDSEDTH4FXXCYG3N5T64XORQBMCLKONCQLQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.0/packer_0.12.0_darwin_amd64.zip" size="10021759" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=32f5e8361acb6c2bb280069820416b4c465fcce6" released="2018-06-14" stability="stable" version="0.12.1">
+        <manifest-digest sha256new="5NTQNRAPWFBE7JNSX5TSVLAGF63MFAKFBJD73UON2UIHKTUXYSCQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.1/packer_0.12.1_linux_amd64.zip" size="10422895" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=fff2a34ff2b8e394e92fef15d88f8440843149f1" released="2018-06-14" stability="stable" version="0.12.1">
+        <manifest-digest sha256new="WNBBURNAG5V3RR42T2QR5H7UY3CLUGLIBZ5O5SYVH2DUBCMKXBXQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.1/packer_0.12.1_darwin_amd64.zip" size="10395909" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=8ed6e75686782ea054bee851bfc3c9ebfcefc3eb" released="2018-06-14" stability="stable" version="0.12.2">
+        <manifest-digest sha256new="NBNK7UG3LKQCJ225FGIQRUKUEHHILCDZDLHP3KNZTYRBUXSQS5DQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.2/packer_0.12.2_linux_amd64.zip" size="10782027" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=490f14c8a131ad48f4349da8e2b84d92651a8e29" released="2018-06-14" stability="stable" version="0.12.2">
+        <manifest-digest sha256new="THIYBTMMZRAPL23YB32U7QYM4Q7RKAMJ24ZBRKUHQI6HVDYE6QKQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.2/packer_0.12.2_darwin_amd64.zip" size="10751758" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=cf18e402f0914429bedb0c225a2d2612bcc194c2" released="2018-06-14" stability="stable" version="0.12.3">
+        <manifest-digest sha256new="V5JP3MXVXVILOGVYY2T2LI4NTO4UT3P6OSJSO4PDKNKLD6H6ADJQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_linux_amd64.zip" size="10756437" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=8ead30fb03fa4d95a1afd8026d83a9f109fd1117" released="2018-06-14" stability="stable" version="0.12.3">
+        <manifest-digest sha256new="YGA7INB3Z2Z23JBVG4Q6YR2NZDANMJSPPUD2DL2M5NNDJE3WQHGQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_darwin_amd64.zip" size="10735892" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=4d969819de0ebcc8f6c0d6c20847f0f1689ea08d" released="2018-06-14" stability="stable" version="1.0.0">
+        <manifest-digest sha256new="6JNJJIX7LJC3JJIK4ITRGR3JV3PPZ372SK55B3EZLETZFU7QGEDQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.0/packer_1.0.0_linux_amd64.zip" size="10761148" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=6bbc03ce402e1c54a33b39339089291e0b1e41f4" released="2018-06-14" stability="stable" version="1.0.0">
+        <manifest-digest sha256new="IZF6AZ74C32WGLERUKVLIZLPD5CD45EB24PEDXPE6H3EK23JBVBQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.0/packer_1.0.0_darwin_amd64.zip" size="10743519" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=d5758f834753f41d48957cfaec0a25c2757d8a4a" released="2018-06-14" stability="stable" version="1.0.1">
+        <manifest-digest sha256new="GETAO3EJL3PPRY4LEPWT4SWHEB5PG3SDYWGDXYUFHQZJIAFMGK4A"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.1/packer_1.0.1_linux_amd64.zip" size="11861730" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=5ad31e254556d1c771c1a5ed17f841801dc1bdb2" released="2018-06-14" stability="stable" version="1.0.1">
+        <manifest-digest sha256new="426ZLPTSXK6GUCOPZNNCOVRWAPV2U7QRSH2CDBALJNLDOC33IM5Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.1/packer_1.0.1_darwin_amd64.zip" size="11835772" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=f59f19201f5cd6766b3aad625e71e0ba4f1d61d8" released="2018-06-14" stability="stable" version="1.0.2">
+        <manifest-digest sha256new="7TATURQURMQ6V4DQSFQF4FUA6UFVUCZT7UYG6XVVEBPPCR7BUQLA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.2/packer_1.0.2_linux_amd64.zip" size="11864690" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=d8e2ec51d9cc28dd0ec0d362bb4e73a4b2ff08b8" released="2018-06-14" stability="stable" version="1.0.2">
+        <manifest-digest sha256new="TC66O6HAEQWSI7MYTDH3ZJOUAYYJRM4LUWWDZV3C54OT35FE2PPA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.2/packer_1.0.2_darwin_amd64.zip" size="11838195" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=d67771d839fa912a6fb4af48c42dc2053869cbfe" released="2018-06-14" stability="stable" version="1.0.3">
+        <manifest-digest sha256new="OMERGLJ6OYWTB5CFAWM3H42BUJWQTTRMXYKDTKVV5ZMSL5WJNYUA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_linux_amd64.zip" size="12096957" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=da20c15f709f13e326f915e4b53b49941afc9005" released="2018-06-14" stability="stable" version="1.0.3">
+        <manifest-digest sha256new="OUKP6F4KA6OAJHDQFXHBG3NBLXKFQW25D4XAMJVEJPKLN32WRLHA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_darwin_amd64.zip" size="12066875" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=ca503df9d22d00208efe53113ef7f3436390330a" released="2018-06-14" stability="stable" version="1.0.4">
+        <manifest-digest sha256new="YJAH7ZR6JEN65CR5ZBD7A7FSHIPWOZDPMOD4QCAQGWFQKIJLSG2Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.4/packer_1.0.4_linux_amd64.zip" size="12095769" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=495734c6947b94edc18869cdd7d4cf417fa37d76" released="2018-06-14" stability="stable" version="1.0.4">
+        <manifest-digest sha256new="HDD3HYM3FENSQBZLXCBIPVNGRZED7P7XNIF4VWBKVXT2ZEEWUPIQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.4/packer_1.0.4_darwin_amd64.zip" size="12067772" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=b1f801d50ce87e16d36d0cebf8c1a6cdfd69ba9b" released="2018-06-14" stability="stable" version="1.1.0">
+        <manifest-digest sha256new="J5QDP7XWF7ZORL2QDLEW3PSSY7XDVEHP7NITIT76OT3XPO5SDC4A"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.0/packer_1.1.0_linux_amd64.zip" size="16582025" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=91a26887cc0383cbf841ec009e6e5ab398d66a6b" released="2018-06-14" stability="stable" version="1.1.0">
+        <manifest-digest sha256new="2WHFZGJVNND6WOUB6Y6FJQAV4UGJIBXYIIR7GXVJWBEKDL32E6OA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.0/packer_1.1.0_darwin_amd64.zip" size="16492367" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=31e456c35a93d8723c5f3d7d4672607316109d6e" released="2018-06-14" stability="stable" version="1.1.1">
+        <manifest-digest sha256new="I2EAFSWSU6F77BUIZOGLGGQASKOMDIMUH6DVY6IPEKTUD5G35OSA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.1/packer_1.1.1_linux_amd64.zip" size="16568560" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=b12289ad83c5e0151ddb2c49a4f917a22a1a5015" released="2018-06-14" stability="stable" version="1.1.1">
+        <manifest-digest sha256new="J5QSGEHHRUWOXPVZ7X3QTR45GXLSHD7Z3RKDLOOKOMETDX25DXVA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.1/packer_1.1.1_darwin_amd64.zip" size="16482882" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=85bd378a6a85a0f5ef072125dbe21f07b2f23c1a" released="2018-06-14" stability="stable" version="1.1.2">
+        <manifest-digest sha256new="FI25AQEXZLC5SETTVGHGNUG2QEUNJ3TY2ZPDFYUHPMU5YMYBYAEQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.2/packer_1.1.2_linux_amd64.zip" size="16581348" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=57ed0cb4bb3d0b8353797a60297a9de16fc9b0ac" released="2018-06-14" stability="stable" version="1.1.2">
+        <manifest-digest sha256new="2S5U6YWT2YDL2XLZKS2JU3COUV4NVT42VONFOMPCZF7EW7O6OWHA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.2/packer_1.1.2_darwin_amd64.zip" size="16497358" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=b81cbf915f6c0b5659c4bedbbaaea6ed73a004ec" released="2018-06-14" stability="stable" version="1.1.3">
+        <manifest-digest sha256new="7AHMURGR4PRGQPCNMJURRS6VBWSRRPQFB6B4QLUXRDBHOYEEMYCA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.3/packer_1.1.3_linux_amd64.zip" size="16661366" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=1126ec2cb85c80e8a858dccf91d8dc5c71ce7d54" released="2018-06-14" stability="stable" version="1.1.3">
+        <manifest-digest sha256new="SHORK3PSJGF5NNM3DMUL7GE7B6SK35IQ7HF37PQAM3BQZRHJ3MUQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.3/packer_1.1.3_darwin_amd64.zip" size="16578524" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=270bee9f20c2044514313cdd4b791fe185bee3f5" released="2018-06-14" stability="stable" version="1.2.0">
+        <manifest-digest sha256new="OEBBN76L7TUPLDABHLZQHUU5VPBFC4IDIUQ5GP7Q3VJUBLPZUCKA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.0/packer_1.2.0_linux_amd64.zip" size="17670947" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=d52b4d1d9a1b7409a977e6472c429a34bc2f19db" released="2018-06-14" stability="stable" version="1.2.0">
+        <manifest-digest sha256new="TUDDJFSYBN6EGCKDCRSLIW4XVM7OHERBRXIFGXCKJRUP6MWVC4PA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.0/packer_1.2.0_darwin_amd64.zip" size="17609766" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=fd9d6f9b463c025a76f9b125f3da9a9e409bf82e" released="2018-06-14" stability="stable" version="1.2.1">
+        <manifest-digest sha256new="F6V6ZGIQ747QU2PER2ET64GWMSQEVQER227VKKVAFNWD2XCL5K6Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_linux_amd64.zip" size="18356943" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=abf0ac07ebc24b7de5615bbcb4b7b427a562c456" released="2018-06-14" stability="stable" version="1.2.1">
+        <manifest-digest sha256new="IVJL4L4YAHTSBAS2ZB3DAQ5SABAW4IH7WE5HTBRAUDWZQOWDG6UQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_darwin_amd64.zip" size="18282292" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=19cdcbd065950cc42f694aef93fe1b2744f74bf7" released="2018-06-14" stability="stable" version="1.2.2">
+        <manifest-digest sha256new="HKZJNTOZM2U7XKO7AGYLNTMH6ZFAU2JLVL43AXYI5PLXJF3E4NCA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_linux_amd64.zip" size="18379262" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=d61fefab26047df1ba873a2b25e1768cf304494a" released="2018-06-14" stability="stable" version="1.2.2">
+        <manifest-digest sha256new="IP4ADJPHWMA7L2OR2UWVTIUUWFJ5F5UDMJZDF7Q3Y2EOJBGX2PPQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_darwin_amd64.zip" size="18306236" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=9c1d7c5efad3074f06abeb67ae6690240d56771f" released="2018-06-14" stability="stable" version="1.2.3">
+        <manifest-digest sha256new="DQF76PMFHPVKDCTQ7YVIFVAJNZXNAP554YUKLWBIWYBBMJ2ILHGQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.3/packer_1.2.3_linux_amd64.zip" size="18754383" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=eafbc27fe0822de3e5267cd249890c48db786f86" released="2018-06-14" stability="stable" version="1.2.3">
+        <manifest-digest sha256new="WCVYGDN5NCOU6KJM4RWUVZ6L3XVYJMRYNW5EHBWQOOJ6IDXHGD5Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.3/packer_1.2.3_darwin_amd64.zip" size="18677147" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=71263bf5158f5ecdf56d72e83aca7268e2b0624f" released="2018-06-14" stability="stable" version="1.2.4">
+        <manifest-digest sha256new="ZVL45EG54GHG75VAVPD6XIHRJHZVUZDS4YITM3PCE53QZKWZT27Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.4/packer_1.2.4_linux_amd64.zip" size="19125512" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=3d6f69205184a4a80a8671c3242d2c530886369d" released="2018-06-14" stability="stable" version="1.2.4">
+        <manifest-digest sha256new="CY5QNE7OFDYLVWAQOS47M7K6JTNUD2Q6IUWF3B7QP7TWUCYXRNIQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.4/packer_1.2.4_darwin_amd64.zip" size="19033721" type="application/zip"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="packer.exe"/>
+      <implementation arch="Windows-x86_64" id="sha1new=571221ee1c159f68f113a787880b9343874f0199" released="2018-06-14" stability="stable" version="0.8.3">
+        <manifest-digest sha256new="JLPLHSWPT7N5CKYHWFY6PHOUTYALRJN3UYZ6B5O7JW7DG3LQZPUA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.3/packer_0.8.3_windows_amd64.zip" size="118799903" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=b9503d8171e9bb35fdcb23de1ef459445ef30699" released="2018-06-14" stability="stable" version="0.8.5">
+        <manifest-digest sha256new="NHDM4KD6RN2ZSXMO5KIBLNDWKXF5IE7FHWU3DYXLJYBFW4GMCY5Q"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.5/packer_0.8.5_windows_amd64.zip" size="118812198" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=b30fc1d265bb4fbbd2e48233c228930d2d26237f" released="2018-06-14" stability="stable" version="0.8.6">
+        <manifest-digest sha256new="JWSU2WEE7FBPXBHDAGLB7RCY5MPQYLNEJKCJ3WFH6AIFD53TN7CA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_windows_amd64.zip" size="131604401" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c8521b4b5e788c503a8cced307120caf29816dd9" released="2018-06-14" stability="stable" version="0.9.0">
+        <manifest-digest sha256new="CMLX3EC3BC5JQWGLZR7USIEDAV7DPH6AK76XTERF3ASYBGOPDAPQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.9.0/packer_0.9.0_windows_amd64.zip" size="8269063" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=874f8025863d13442bd2918e51a8306dfbf21a0b" released="2018-06-14" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="MA6BGTNR3UPA2Z6XXU67VKYHE7VTJDXGSU346H6MFOUMFF6CJRYQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.0/packer_0.10.0_windows_amd64.zip" size="8774782" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=381bb1519e28426768c4878900740c120c24bff6" released="2018-06-14" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="WC6VDRMCGAIOKHJ2CR3I6B6BFZMEMWZC6XQOHGV2WY2IDQVMJE2A"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.1/packer_0.10.1_windows_amd64.zip" size="8934224" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=60497ee8d5dc5e61d637f70ca79256e966359983" released="2018-06-14" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="K33XAKZTIN7WUDDVXXWZXYADXMZPNCM43F625PDOAWPW7PW2S5OA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_windows_amd64.zip" size="7947975" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=35f5f45162b7d1675fd6fa63a6bb6e2df5ce87ac" released="2018-06-14" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="KC2UZRNRAOPJXTZZB7RD4B4DFQKHYP54OWM7ON4KTZLSLYZZBKFQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.11.0/packer_0.11.0_windows_amd64.zip" size="8436541" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=dd1ae9cd3a93f66150e731d31ed0f8386b109066" released="2018-06-14" stability="stable" version="0.12.0">
+        <manifest-digest sha256new="62IF3CWSCMTRTUHKCCZSRJ5NSQLUDVUWF45VRPTBF4LQE4EPDSVA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.0/packer_0.12.0_windows_amd64.zip" size="9955113" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=ad686cbe8bd071a2bc7a7b246637b7029e4eb41d" released="2018-06-14" stability="stable" version="0.12.1">
+        <manifest-digest sha256new="4PBA3TZSJCK3K4M22QSZMKEXQP7OFWB7L3QBVVNQKUWPI6XLPLTA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.1/packer_0.12.1_windows_amd64.zip" size="10347291" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c7aea5fd184edf20a91f1710e838979ebe27b101" released="2018-06-14" stability="stable" version="0.12.2">
+        <manifest-digest sha256new="EIWTIVYELVA6VY6NUEGBOTSPQDZ3BSFDUAM4NYKGLFBNIZDZXCRA"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.2/packer_0.12.2_windows_amd64.zip" size="10716093" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c2a644b0cc3c8618813858ae6f6f1e55bd45a8c5" released="2018-06-14" stability="stable" version="0.12.3">
+        <manifest-digest sha256new="ZDFQK6OBG7XFEH75YZTHYJ2QYM4S2QGQ62NBU5VWNEPR5B22HBCQ"/>
+        <archive href="https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_windows_amd64.zip" size="10701869" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=3a2057707cc139b39bcff14c7d187952d8a6d506" released="2018-06-14" stability="stable" version="1.0.0">
+        <manifest-digest sha256new="YJ3CEM4MPX3OGNPACP4FRQU7BDGJ5M5Q4N4Z5DOXJHAJDHKVGX6Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.0/packer_1.0.0_windows_amd64.zip" size="10710900" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=efb24a3a82982096bb78a3db2eb236037805d4e7" released="2018-06-14" stability="stable" version="1.0.1">
+        <manifest-digest sha256new="AQXAQWP4FG3LOQS7NJDJQYXMYGJ5Y7WPF4E5HOZJBA4V3UFIFASA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.1/packer_1.0.1_windows_amd64.zip" size="11796211" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=90a4c07bcb2af607dd804099c88b8becaa802d8a" released="2018-06-14" stability="stable" version="1.0.2">
+        <manifest-digest sha256new="K4EIAB3TCPTNFEETQFESLNFCUSXJHUIBAJ5SRSFSKUEKYDLQGADQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.2/packer_1.0.2_windows_amd64.zip" size="11794836" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=a78df4370a5f9ba9fe17fed56cb01adcd10ae074" released="2018-06-14" stability="stable" version="1.0.3">
+        <manifest-digest sha256new="7NAR4GQHTQAPKMVCMWADZMVSRLQCPPSNXJ7HVKFJDBV3XU6JH6QA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.3/packer_1.0.3_windows_amd64.zip" size="12029179" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=bdc7cfad7f4162a3b68d8dcbda2bee8b1375059c" released="2018-06-14" stability="stable" version="1.0.4">
+        <manifest-digest sha256new="XCGLQUTYYGH53O764GJL2LYBRYXLJIUOSJ2VWVF4LPN4MM7KEYBA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.0.4/packer_1.0.4_windows_amd64.zip" size="12028822" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c188a158971cb3653a347c59d944d33a22d55f62" released="2018-06-14" stability="stable" version="1.1.0">
+        <manifest-digest sha256new="KEB5ZR3PMDR6VTUHHPBKS2WSB6QBTQ7JLZEHFWKBAGZD6PKQ7W2Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.0/packer_1.1.0_windows_amd64.zip" size="16480628" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=96c54491449100ad7d1faa7e602db95826a878cb" released="2018-06-14" stability="stable" version="1.1.1">
+        <manifest-digest sha256new="KXZAAV5YNDH6JZSAMKATDPR3EVZYXEDV6IWWJILUNIZWRC5P5YHQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.1/packer_1.1.1_windows_amd64.zip" size="16471316" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=f5f4148ecb0dff72b69007d0774ea48c3573c81a" released="2018-06-14" stability="stable" version="1.1.2">
+        <manifest-digest sha256new="MF33MYYOFH5TSEP5XA3PPPWIP56AI2WJ6NZ6CCINFVWQVT5YG5XA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.2/packer_1.1.2_windows_amd64.zip" size="16485584" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=4468cc0f9253e73bfff242db604388d1c2cae3a7" released="2018-06-14" stability="stable" version="1.1.3">
+        <manifest-digest sha256new="MNWUXUTED7C55JOZEFAUMCZFNOVYEY7UFW5EWA6EOZUR6XZYSMYA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.1.3/packer_1.1.3_windows_amd64.zip" size="16566685" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=543e489f95030653e8ea9fd8b62ec3f9fbe33ed0" released="2018-06-14" stability="stable" version="1.2.0">
+        <manifest-digest sha256new="SJN37ZPHK6IWPZ5JCJVE2CH3HK4NGRKPDUX53NNFOF4EL2ODTAGQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.0/packer_1.2.0_windows_amd64.zip" size="17583556" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=3c28e5f116b4e04528b9c196706c5acb302d4578" released="2018-06-14" stability="stable" version="1.2.1">
+        <manifest-digest sha256new="XHQ4O4D3PWMJIJBGSY333PJMZWQDUWQ5CZ7ENEQKYFJ4HX4XWVOA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_windows_amd64.zip" size="18173560" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=ecddeb45af834ae1692e499c85fe089cb18e9021" released="2018-06-14" stability="stable" version="1.2.2">
+        <manifest-digest sha256new="CJYCJJZI7I4GQRSIPJXELPGA7K2LVS3SJD2QS5Y2MKEYYS7B7OGQ"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_windows_amd64.zip" size="18196038" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=43b29866b18a7da6b3c45aa35b2a51e59f75a518" released="2018-06-14" stability="stable" version="1.2.3">
+        <manifest-digest sha256new="MY2FT7GOCHY75CFICGUI6LF6KIEIFPAY626OIMAED2ZCCHX6EEEA"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.3/packer_1.2.3_windows_amd64.zip" size="18597555" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=9ce1b36c2e36148cd2be7a121174522b6151a047" released="2018-06-14" stability="stable" version="1.2.4">
+        <manifest-digest sha256new="E2GG5IBRGTJBXBOII5G2Y3NR3EFPTPCIBXAA3ELFLXMKH6KOWM3Q"/>
+        <archive href="https://releases.hashicorp.com/packer/1.2.4/packer_1.2.4_windows_amd64.zip" size="18967336" type="application/zip"/>
+      </implementation>
+    </group>
+  </group>
+
+  <entry-point binary-name="packer" command="run"/>
+</interface>

--- a/hashicorp/packer.xml.template
+++ b/hashicorp/packer.xml.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Packer</name>
+  <summary>build automated machine images</summary>
+  <description>Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.</description>
+  <homepage>https://www.packer.io/</homepage>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/hashicorp/packer"/>
+
+  <group license="Mozilla Public License 2.0">
+    <group>
+      <command name="run" path="packer"/>
+      <implementation arch="Linux-x86_64" version="{version}" stability="stable">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/packer/{version}/packer_{version}_linux_amd64.zip" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" version="{version}" stability="stable">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/packer/{version}/packer_{version}_darwin_amd64.zip" type="application/zip"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="packer.exe"/>
+      <implementation arch="Windows-x86_64" version="{version}" stability="stable">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/packer/{version}/packer_{version}_windows_amd64.zip" type="application/zip"/>
+      </implementation>
+    </group>
+  </group>
+</interface>

--- a/hashicorp/terraform.watch.py
+++ b/hashicorp/terraform.watch.py
@@ -1,0 +1,5 @@
+from urllib import request
+import json
+
+data = request.urlopen('https://api.github.com/repos/hashicorp/terraform/releases').read().decode('utf-8')
+releases = [{'version': release['tag_name'].strip('v'), 'released': release['published_at'][0:10]} for release in json.loads(data) if not release['prerelease']]

--- a/hashicorp/terraform.xml
+++ b/hashicorp/terraform.xml
@@ -1,0 +1,519 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/hashicorp/terraform" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Terraform</name>
+  <summary>write, plan, and create infrastructure as code</summary>
+  <description>Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.</description>
+  <homepage>https://www.terraform.io/</homepage>
+  <needs-terminal/>
+
+  <group license="Mozilla Public License 2.0">
+    <group>
+      <command name="run" path="terraform"/>
+      <implementation arch="Linux-x86_64" id="sha1new=59d3c9e88b9777597aea67124fd30e1b9eacb997" released="2017-04-26" stability="stable" version="0.9.4">
+        <manifest-digest sha256new="7H45PYN6ROA7TSKXZCE5BFG6EN57WFQBTDFX27RAEDBOXDNT5SFQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_linux_amd64.zip" size="30474173" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=fe9a26ef1750497febcdeb22a73678f27fa016e3" released="2017-04-26" stability="stable" version="0.9.4">
+        <manifest-digest sha256new="4DIEIJYS5NONXAGQZ2KBDJF44YS2UKRWPRNETFNAI46QNVJFLKYQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_linux_386.zip" size="27221729" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=5bfd466f948bd638a518bf412b34422113013d78" released="2017-04-26" stability="stable" version="0.9.4">
+        <manifest-digest sha256new="YMWESQAGQGOKDLF7XMGH4Z4UALFOMBCKGLM33ML3EJY4AELWZ6FA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_darwin_amd64.zip" size="32301547" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=0dcf02e8f37fd6801e3804188eb34d6b57b8ed61" released="2017-05-11" stability="stable" version="0.9.5">
+        <manifest-digest sha256new="SFTKBSMS5DMF4NELVHZFSSEPR2WG4LHNDFINTRHFKG7VCK5YS6YQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.5/terraform_0.9.5_linux_amd64.zip" size="30720943" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=8b898871b828879ebe5a6343864cebdb80dafc5e" released="2017-05-11" stability="stable" version="0.9.5">
+        <manifest-digest sha256new="YR2KQFBHDOJQQBSPM62W5GX667KCBWRV7JWZNRUBL2UNOE4JAX2Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.5/terraform_0.9.5_linux_386.zip" size="27436217" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=faed35a1a9ce096661e6e13fc6470ae5972901ba" released="2017-05-11" stability="stable" version="0.9.5">
+        <manifest-digest sha256new="AR7KR6JCYKRYHYV3BGZRTJ25UETWPM5FYXOIZSTDMIOUD4VYTYKA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.5/terraform_0.9.5_darwin_amd64.zip" size="32559723" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=becba5c19dc94adb1c1931b4a43bcd954f3c06c9" released="2017-05-25" stability="stable" version="0.9.6">
+        <manifest-digest sha256new="JUOCM7Q5SWP4GQAK2OYTFW6PU2COC6I2ECO5W4MUTWHXUGG25CTA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.6/terraform_0.9.6_linux_amd64.zip" size="31161794" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=ec41f9f04fbb83c3ce62a0be25ed08eb5b68612f" released="2017-05-25" stability="stable" version="0.9.6">
+        <manifest-digest sha256new="ERQOD7XFECL6ZKBDAQXUXCABSZOPEPSVH2JO77GXSLGHW6QBIBXQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.6/terraform_0.9.6_linux_386.zip" size="27801677" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=a27a63ffb881649970ccf060fe284fe9a8595815" released="2017-05-25" stability="stable" version="0.9.6">
+        <manifest-digest sha256new="BL7ZVOW2JO2KD4FQZVWTPBHEPSAA7FT7TET24I23VWKXIZSRTNLQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.6/terraform_0.9.6_darwin_amd64.zip" size="33017162" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=65c807898f28f2cb222032e58ddd39e8ac385abc" released="2017-06-07" stability="stable" version="0.9.7">
+        <manifest-digest sha256new="5XOIM3FD7SQF5FAKWWHA6WNU5PFMR2ESVXU7ADJSEJF5WJSL2MKA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.7/terraform_0.9.7_linux_amd64.zip" size="32348336" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=b212980e762cd8447cb912ec24a06290905c4c7d" released="2017-06-07" stability="stable" version="0.9.7">
+        <manifest-digest sha256new="NJVMYB2OITMYVDZQEXASEZ3JBRRXU5CH3LGAB6UFSX5PUXYHD4CA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.7/terraform_0.9.7_linux_386.zip" size="28851443" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=a6f3ce3fa140efbd286a192aae57ebbc82ad4ca7" released="2017-06-07" stability="stable" version="0.9.7">
+        <manifest-digest sha256new="XFF2TUJTN6S7BO3BBHG7TNEP3IKM4M7WKAYCZKVQLFYJK6FH7Q7Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.7/terraform_0.9.7_darwin_amd64.zip" size="34283094" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=3335495d02a360d22ae33048ff61727642a59a49" released="2017-06-08" stability="stable" version="0.9.8">
+        <manifest-digest sha256new="MK75DBZAKQQHBZMNOOO7FQZFF3S4JJW73F3KSHZ3A35NOISDQ4GQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.8/terraform_0.9.8_linux_amd64.zip" size="32349056" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=9c893888047a4042343f043e10ddcbb7397dbd33" released="2017-06-08" stability="stable" version="0.9.8">
+        <manifest-digest sha256new="GTFWQ5CZKX5Q36AZSGFHOEKIAWO2DEGRDCQ7TWA743YB2QNLW4XA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.8/terraform_0.9.8_linux_386.zip" size="28855210" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=3069406abe518c68d9290e65197f76761eaf39c7" released="2017-06-08" stability="stable" version="0.9.8">
+        <manifest-digest sha256new="MHHBKYECQ5Y7RYXU3RUG7E27ABHADQCHGTV3U7T3ALUWWNUVN7FQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.8/terraform_0.9.8_darwin_amd64.zip" size="34283759" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=a336ab9ce77ba8701bdc1fa0205bd444601fd5a8" released="2017-06-26" stability="stable" version="0.9.9">
+        <manifest-digest sha256new="OAGWEM7DTMYFDTIVZFGJX7YSNNN2B2GW4CH42AXG33UWOU3DEYIQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.9/terraform_0.9.9_linux_amd64.zip" size="32346958" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=f039ad88d6be267cde53782be1a517ce2c727011" released="2017-06-26" stability="stable" version="0.9.9">
+        <manifest-digest sha256new="XVTUFSKTSWL2LXRWRZX4YQFKK3ADVGQPDJFO5LJQRNNCFBWKTLSQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.9/terraform_0.9.9_linux_386.zip" size="28853592" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=b2ad1490e3ef1a7c4cb0b31e45079ec6611a3129" released="2017-06-26" stability="stable" version="0.9.9">
+        <manifest-digest sha256new="TPA3W7DEGTKJ3UV7QA76SWZSBKI5EIH7F6HPK7IXH735KRTGEF3Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.9/terraform_0.9.9_darwin_amd64.zip" size="34283907" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=a7ac4c334e177e9ae63e4f926879310f1b9eae1e" released="2017-06-29" stability="stable" version="0.9.10">
+        <manifest-digest sha256new="I3J42SHXZIDYRCB46XOR4NWK43PJ4PKKY72H4HCSCR5JIIBO62XA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.10/terraform_0.9.10_linux_amd64.zip" size="32346570" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=395a17a9aeb3f6abfa336aceb7b8a9ce5255a22f" released="2017-06-29" stability="stable" version="0.9.10">
+        <manifest-digest sha256new="LKTS2ZKDKRA3XHTYX4HRZTBHNICUAWQ52HSYBOLN6SYB6AKDVZMQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.10/terraform_0.9.10_linux_386.zip" size="28853126" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=ce9593ac7404a4049793ae346ddc952b900ffab1" released="2017-06-29" stability="stable" version="0.9.10">
+        <manifest-digest sha256new="RKIITGB3IVI2Y5D2OYICMBGZONC6C5W46UUZX7UYBHPHYGMQ4S6Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.10/terraform_0.9.10_darwin_amd64.zip" size="34280362" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=4adc7643682a062ec849cca081451d97009f3756" released="2017-07-03" stability="stable" version="0.9.11">
+        <manifest-digest sha256new="MUQMA4N3AFJ4CARBHH7L26RI7QTXGNIEYTKJLLP4NUCG5SZHHQMA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip" size="32347322" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=31b209ed4c20d8deba338f5703412a942d749cf4" released="2017-07-03" stability="stable" version="0.9.11">
+        <manifest-digest sha256new="CWLSNSWYBADH5C3MTLI26FEPZ2ABZJAGVSD73LJBBOR7MHTE24UA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_386.zip" size="28854153" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=cfff7efbe6baca66db365d4bd6c803bcc71f6992" released="2017-07-03" stability="stable" version="0.9.11">
+        <manifest-digest sha256new="ZVKE6G4CVERT6KQHJ34ZW66KPVV76ETTKNC2TGKRX4ZQVDOC3M4Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_darwin_amd64.zip" size="34282002" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=584b723c7c4c28b0336466c0b4590bc700561521" released="2017-08-02" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="WZDYITWCA43O2HD2JPJG2TUCCE2B4WCDUKEGTXPMX3IEV76C2HAQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_linux_amd64.zip" size="12259322" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=5cf00bf919926face55d66c9ecedf05438819f35" released="2017-08-02" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="ZKPSGAJAEVNMCSF5573BJCOGWJIVW7PNYZH5QDOIV7JCR6YNF4GA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_linux_386.zip" size="11121509" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=d65f916382abec5382652dbcea68b3c0b67df46a" released="2017-08-02" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="J4SEITBMC4O3OWWLJ66F62R3BC4TAQXG3IQ5E3D4T5PNNNWK5P6Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_darwin_amd64.zip" size="13153241" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=368a44418189da88110515bc8738b8ad1f2983d2" released="2017-08-15" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="SXADONKWXIH5X3NVHWX4KYNFW3N24P7XE3EPBYDDYHFW3CCRW4HA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.1/terraform_0.10.1_linux_amd64.zip" size="12455657" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=b4d050b135109ab053572cc511f001be241a46d7" released="2017-08-15" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="ZIH32F6KDQFUTXK2SEN2MBBKHSTDJXFLTBMON3KV7YG43TEWZLOQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.1/terraform_0.10.1_linux_386.zip" size="11304485" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=ffe0eaa949d72ea4f45c41f9a1ef1678e04b7bf9" released="2017-08-15" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="2IP4PND2CLGXL34YGWOBEGSWYXAFGOUMYNNRJEE62A5YR6UUIHIA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.1/terraform_0.10.1_darwin_amd64.zip" size="13361680" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=e6c7ef54857231c010701f217ed382f446ab0fd8" released="2017-08-16" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="67TILF6QXBJXMO56PXVXEHCUSVZQW6GS2AGIIETCWXFR6XTC3XFA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.2/terraform_0.10.2_linux_amd64.zip" size="12453950" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=e4d7ffc149de59f5189c0f6ca759a753733753b7" released="2017-08-16" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="EG5U2OAHBB6NSIGTNMUIKLJA446A3NOXOFWZP32DF6EWPYKSNTKA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.2/terraform_0.10.2_linux_386.zip" size="11303745" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=cced97d82698f3796e54d6a11bdf2edf0fe62ea0" released="2017-08-16" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="RQDTHTUKEULUPGUOMPT3WF34C2WBBOGAPME6CCB2S3TN4J3DN6BQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.2/terraform_0.10.2_darwin_amd64.zip" size="13358989" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=8e62e925db06a7bb9c5bf1c927d1c2e08c5f56c6" released="2017-08-30" stability="stable" version="0.10.3">
+        <manifest-digest sha256new="7DHOZIICSXLGMJD72SV3ZIOGAKPADG6MCEUKGJONII6JWFPNNO2Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.3/terraform_0.10.3_linux_amd64.zip" size="13122639" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=44201657b451298862940b3b1d7f4aca419756ce" released="2017-08-30" stability="stable" version="0.10.3">
+        <manifest-digest sha256new="QNTCLINWACOI33Q7DFK6ZKQBJHLWTIREP732RZOTYA7OHYL5J7GA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.3/terraform_0.10.3_linux_386.zip" size="12026597" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=75b83a785fa34031b121706e9666ca9c4dbfb63e" released="2017-08-30" stability="stable" version="0.10.3">
+        <manifest-digest sha256new="EP4NJMNOGWGW72Z6Z5G72OPF5HXFA7MMAMQQH725GZKDJ56WPWVA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.3/terraform_0.10.3_darwin_amd64.zip" size="14061108" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=870ba84e9fe0b1631884dd642435394a761e967e" released="2017-09-06" stability="stable" version="0.10.4">
+        <manifest-digest sha256new="S7UTVRTN4PXEPNORV6ZWKQ6EUJ4JVANUK7EPUCG6EAMLWQWT7RJQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.4/terraform_0.10.4_linux_amd64.zip" size="13478898" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=fd13f05fcde51b1a139f3157088a713bce432bae" released="2017-09-06" stability="stable" version="0.10.4">
+        <manifest-digest sha256new="EY7FK5LLOETMDQLCSR77Y52FEH6SPIPQLXRMOPSME7XX23XUSAZA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.4/terraform_0.10.4_linux_386.zip" size="12352209" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=de7ca4d980aca292482562ecb19357a668d7fb0e" released="2017-09-06" stability="stable" version="0.10.4">
+        <manifest-digest sha256new="Y5LDQNQMTY72PXVVMDLVQCYO2VOG2KOKNXIJ74E7ZYB4RX3IG5NA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.4/terraform_0.10.4_darwin_amd64.zip" size="14452942" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=ba0305fc6eed6feeab7ad66cf1eae802c9db36e0" released="2017-09-14" stability="stable" version="0.10.5">
+        <manifest-digest sha256new="CGIBAPXTE57ZQG2U5JFDO3FXSO4H5RWGZQLWFISOPBERYPH75BQQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.5/terraform_0.10.5_linux_amd64.zip" size="13480473" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=3270c6db2f64b5264f8ad9771e47f62ea3f4c8d7" released="2017-09-14" stability="stable" version="0.10.5">
+        <manifest-digest sha256new="E6R2235NUXU22KZ77224S6UWCPXY2USBVROQPYV7PG7X6TUTWKJQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.5/terraform_0.10.5_linux_386.zip" size="12354495" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=ccf6c009a5d26e5e171f04a20d0cf9f461c530d2" released="2017-09-14" stability="stable" version="0.10.5">
+        <manifest-digest sha256new="YKYIKXBBQ3KJBET25GJ3DGPFUEZVA4HQ3KQ6SSBXPASNNZFI55DQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.5/terraform_0.10.5_darwin_amd64.zip" size="14459706" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=a527100ba06ad324aa7515a4abfb3cb922994060" released="2017-10-02" stability="stable" version="0.10.6">
+        <manifest-digest sha256new="6GSJYUXGLKX2TVJD66PXEHZOMW4WPFJUM5NSENEAFTOMCQTCKHIA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.6/terraform_0.10.6_linux_amd64.zip" size="13482562" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=c5f7c6524d1cf16cbae4144accf3072e9a80675a" released="2017-10-02" stability="stable" version="0.10.6">
+        <manifest-digest sha256new="T5EAGMVPMJE6AIBDHQGFKKRFCRLQTLW64YN5D5IZBEBHLFJ2NUVQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.6/terraform_0.10.6_linux_386.zip" size="12355436" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=fe66c064440f4b2da114e0bfdb4671c380be54d0" released="2017-10-02" stability="stable" version="0.10.6">
+        <manifest-digest sha256new="D5VVACU6JEIGFGS6ENDFQES7UEZYIJ4RWTYQKUN562GNBJJ7A2RQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.6/terraform_0.10.6_darwin_amd64.zip" size="14459018" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=757710a226933eb9b24289da7fe223e99e33b263" released="2017-10-02" stability="stable" version="0.10.7">
+        <manifest-digest sha256new="3L3R5NGLLYJO5MB653B4OSS3CLOSKBNOXIAJDNIHCAIT6WH2FTXA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_linux_amd64.zip" size="13501640" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=29024ac44b712a8546f6c79900e2feabcd413c51" released="2017-10-02" stability="stable" version="0.10.7">
+        <manifest-digest sha256new="ENQRNSCALJJ6LKMWCUMTFSSTIOS3SIO2J6CTEXK5C524QUQ3DLVA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_linux_386.zip" size="12374486" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=f8778e0b6ce13c516c02259dafb9fd2a60aa1741" released="2017-10-02" stability="stable" version="0.10.7">
+        <manifest-digest sha256new="YBHOJ3G2Z545OMSUN5OORXCLUTTM4Y53VDNPY74WLLXHGJ4UNSSA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_darwin_amd64.zip" size="14481385" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=041c1ac8167c532fc848811bb9c2954da5e6861f" released="2017-11-02" stability="stable" version="0.10.8">
+        <manifest-digest sha256new="7TZZNKUU6CG5CZXGTIJBWOEWCRZEMPDZIIIAFAUEZ5NYJQWLHNMA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_amd64.zip" size="14485524" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=64ecaba5b5b1bb8174b86a3c0c68b945ad97fe6d" released="2017-11-02" stability="stable" version="0.10.8">
+        <manifest-digest sha256new="4EOQAREE427RIQWVDJWCB47ZPZZMMP6XOV2O77XCQ46UGG4OCCEQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_386.zip" size="13273630" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=5a8356470644e823ab33327de7036322d3ca576d" released="2017-11-02" stability="stable" version="0.10.8">
+        <manifest-digest sha256new="QZUEFVJGWICLL7J5G7L7A7PSBZPNMLC4GEWX7IDMLT77BVYPQYCA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_darwin_amd64.zip" size="15515299" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=a59e9f91c75a88f058d2cea854aa73853d49a0fb" released="2017-11-16" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="Z7JPSUXCK45JIILC7ZJSVP725GJHETEPHVVXNLV4K7MRO2RR74QQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_linux_amd64.zip" size="14713368" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=326c6baea09b03eef746ed2638618cedb431102a" released="2017-11-16" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="VQIUY3E7MJ7XRYRQ5R6JQ2ZJCIEMQHK5V3HFYT6B3ASMPTHGR56A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_linux_386.zip" size="13481358" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=1dadd04e2b47a75736719c5ba7fad13549a070f0" released="2017-11-16" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="TDCKA47JNWCUB2PCXDMFW3KRLKJZEJ3JMBY4BMZFG5QC4D6SWEDQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_darwin_amd64.zip" size="15753806" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=3ee3564372a5c9c6016ee168e5bacfe63ef0ae94" released="2017-11-30" stability="stable" version="0.11.1">
+        <manifest-digest sha256new="PWQ6GFYJ3RYS46AUBQEPHA2FPPS5R7C4GJEIWKDL5YSYMRVWPG5Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.1/terraform_0.11.1_linux_amd64.zip" size="14709002" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=55bb9da18a485cbc665039458ebf3f1f1e1eeda4" released="2017-11-30" stability="stable" version="0.11.1">
+        <manifest-digest sha256new="ZEW2AAKLOPTD4KOHWSEZXXRZQ2GEPLEXY4ZHRNEQSMQCHT7F2T3A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.1/terraform_0.11.1_linux_386.zip" size="13479680" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=76d9023308221d60b94750bf30033f740b5b5176" released="2017-11-30" stability="stable" version="0.11.1">
+        <manifest-digest sha256new="OLLUSNPBE74CYPGLZTOU4WDFFZHYFWS6TJM4YYFNAAEZZBMETQTA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.1/terraform_0.11.1_darwin_amd64.zip" size="15750266" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=49f8921123163fb0a9a9a71701549219579393c4" released="2018-01-09" stability="stable" version="0.11.2">
+        <manifest-digest sha256new="MR4V35WWY4AQHWQTVWTRPJGG7SD6XC5ILKWK6DHEQGX23CHHXDWQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_linux_amd64.zip" size="15306618" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=47eef5052714a6e0dd8424ca539a5a155387416d" released="2018-01-09" stability="stable" version="0.11.2">
+        <manifest-digest sha256new="A3ZWAW3ZXID4AISHMEM2L6T55F47KUSO54LLDZNGPMLRQSLICLAA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_linux_386.zip" size="14014041" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=febb140b0e025456998d977e502c5cab97a90ec2" released="2018-01-09" stability="stable" version="0.11.2">
+        <manifest-digest sha256new="R3QBHDW3GI3YP2XM637QYTGUE63T7UL4BC4DHZLZSGFNKGYKECEA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_darwin_amd64.zip" size="16406847" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=353e3ff7f8dfaaff1a7c3d41dfd108edd0edcc84" released="2018-01-31" stability="stable" version="0.11.3">
+        <manifest-digest sha256new="N3TKDTUUAKH45C26CSREB7QQ3PBANVBPBWXWVVTVQ2XLOZGM5PCQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_amd64.zip" size="16466291" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=e31b7538f0894f904a31139385204994b3eaf2e6" released="2018-01-31" stability="stable" version="0.11.3">
+        <manifest-digest sha256new="VMF6LOMX6JII7W2NAPKVYL5NBABRMP2V3KAMN53WXTDLHHONV55A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_386.zip" size="15061964" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=2423ec1203809867326ad47a524081b841ade00f" released="2018-01-31" stability="stable" version="0.11.3">
+        <manifest-digest sha256new="URYZKRLHXS7DUML3FTED43KLT5Z7QFASJKN3KLZ2MLGKM6IO5NXQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_darwin_amd64.zip" size="17694867" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=41fb22029f5dc5bdfc508e8dc3d72e8e22f5186e" released="2018-03-15" stability="stable" version="0.11.4">
+        <manifest-digest sha256new="ZB6UC36FLHEUCLICPTTHU6JX64E6OHXW5G3SYBMINGB36DBXPEYA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.4/terraform_0.11.4_linux_amd64.zip" size="16475160" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=7b4a3ab038f7af2e62681f44a8e249e9495648ea" released="2018-03-15" stability="stable" version="0.11.4">
+        <manifest-digest sha256new="OCXLKCQDH2TDI5TAFJ22IKLMG6ZLCWUKATUOQ3OVI63XZ5WPJXRQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.4/terraform_0.11.4_linux_386.zip" size="15410434" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=fb1b68cd918e43ca18dbd18716640f2c70863ad9" released="2018-03-15" stability="stable" version="0.11.4">
+        <manifest-digest sha256new="3IAGKD5BPBB34HUFHOPGU7B7EYIIYESVO5G6TASOZYTF43ZNHUBQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.4/terraform_0.11.4_darwin_amd64.zip" size="17735102" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=331f44182e6bc30d3a8ef22382c6583b3aa40b3f" released="2018-03-21" stability="stable" version="0.11.5">
+        <manifest-digest sha256new="26PZZB4IFXTFOEDWUTJSBTJ6IJCSPGH4J4NU2DNNOVNHHFI4EYOA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.5/terraform_0.11.5_linux_amd64.zip" size="16479399" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=ac28e77f02ff58c00f100d43c1856d5f5a13fec4" released="2018-03-21" stability="stable" version="0.11.5">
+        <manifest-digest sha256new="OHLNTDFWGIMPJS3TZTRBDMXK6ER576H22NKF72LCOQ7MB6FWLLZQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.5/terraform_0.11.5_linux_386.zip" size="15410429" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=fbfaa52c0d149c65ae898f8de2d04dac02d9019b" released="2018-03-21" stability="stable" version="0.11.5">
+        <manifest-digest sha256new="7UQLQ2D4SXVUXLI4AGUTGRIV2SRLCM4LBGGPV2IUW5N7EAKL4M3A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.5/terraform_0.11.5_darwin_amd64.zip" size="17738450" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=cdb4b6fd6bad8a476f6e66b79cb7d58322176012" released="2018-04-05" stability="stable" version="0.11.6">
+        <manifest-digest sha256new="XXK4EILHNHYYV3IK3D6CEAAXLYDAQO7BN3YDR7MEZ5HMQNQAIV5A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.6/terraform_0.11.6_linux_amd64.zip" size="16488389" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=694974d35b83d3bf39dc9a0b6779fba404ebbf63" released="2018-04-05" stability="stable" version="0.11.6">
+        <manifest-digest sha256new="PWNEE6TG6CTO4XLPAXXVTFGFWKRPTZJMMALX6MES23SKMRNDPY5Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.6/terraform_0.11.6_linux_386.zip" size="15421193" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=de80cb543480fed571595d96620a8d83e7a5017b" released="2018-04-05" stability="stable" version="0.11.6">
+        <manifest-digest sha256new="NDCCAOJANAEMZYRCDHB3J2AIF7BZ6N7JYQG4WHB2YZMG3PEBFQMA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.6/terraform_0.11.6_darwin_amd64.zip" size="17747622" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=1d4bc5900bc3789b19373e91ea151d32018e6a7c" released="2018-04-10" stability="stable" version="0.11.7">
+        <manifest-digest sha256new="AL7XA5PIIY5D465GBXI3YY7434YBSBOPPBVL6FWBH46U6JJ55FDA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip" size="16490308" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=f581f868674a56bf7bb58ae83b20a9e97cbebe9c" released="2018-04-10" stability="stable" version="0.11.7">
+        <manifest-digest sha256new="B7UJIFFOQBVRUKY6ANAS7Z7JSDHX2RRIVKSQE23VQAFNRSUMT5RQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_386.zip" size="15424573" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=fde56ac35d0da5a7c493b71fbe0db61acac6af01" released="2018-04-10" stability="stable" version="0.11.7">
+        <manifest-digest sha256new="LMZXMCDJCN67XGW7NKSJMTUNY4PYEFUVHQFMLWW5EAN3NTLXZILA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_darwin_amd64.zip" size="17754416" type="application/zip"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="terraform.exe"/>
+      <implementation arch="Windows-x86_64" id="sha1new=0a10ba4cb2b208384fc5a3957da54a5e26975a37" released="2017-04-26" stability="stable" version="0.9.4">
+        <manifest-digest sha256new="G4V5KPVOHFTSVR5BWOVVVGFBQR76DKUQ5XO35CYOJAJ4CW224TMQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_windows_amd64.zip" size="30576542" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=08fefacf495cfa32b42479375bd067b9fc7ef65d" released="2017-04-26" stability="stable" version="0.9.4">
+        <manifest-digest sha256new="WBXVS27XBK5OSFRQTLO3TNBBVDKCVVFFNL7N6S2A4ZMMOFWNXDUQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_windows_386.zip" size="27224797" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=cefdfa84790c1fccddd70ac0be1b186464534428" released="2017-05-11" stability="stable" version="0.9.5">
+        <manifest-digest sha256new="CYD5NDDC2FSF6F7CB32NCNVODOHS6CGTMW2J4TX7DX66YA3BIW3A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.5/terraform_0.9.5_windows_amd64.zip" size="30822957" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=21acc2bc0a7ab1a10d5878b15ff29079d5138df1" released="2017-05-11" stability="stable" version="0.9.5">
+        <manifest-digest sha256new="AFAZDCQ3XECCA2FQQTR77XGJIZH5MFDKP5257ZNRHGYZNLWPPAEQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.5/terraform_0.9.5_windows_386.zip" size="27442135" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=86adc7746a9fa030a3438013c67b920ed23f02eb" released="2017-05-25" stability="stable" version="0.9.6">
+        <manifest-digest sha256new="M2GP2RBCVGYCRHLMCM7CEYZOBO7WUD46MDLZWHDXTRJIL7YTZMYQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.6/terraform_0.9.6_windows_amd64.zip" size="31269130" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=f8f9314873a4c6ec5c76906743740d8f16eb053b" released="2017-05-25" stability="stable" version="0.9.6">
+        <manifest-digest sha256new="T4BOEXHEEX6Y6CHMX66MHBSQQ53BXMTHO5EAM526JEVYXFAXTXFA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.6/terraform_0.9.6_windows_386.zip" size="27819699" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=515708ab61e59e9dd1c60df2ab806551e1f0a443" released="2017-06-07" stability="stable" version="0.9.7">
+        <manifest-digest sha256new="BWVEQREKQ7BSCP6W23NBZM4CNCEUV674G4XYA6QWI3GENRTJMIUA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.7/terraform_0.9.7_windows_amd64.zip" size="32454916" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=966fe20aa8856377ec734b20f47261637256834f" released="2017-06-07" stability="stable" version="0.9.7">
+        <manifest-digest sha256new="KM5SE37OC5UWRNL5GQNLIE6BGOC6D7VJFTNHKNTX3LHGRHR4C2QA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.7/terraform_0.9.7_windows_386.zip" size="28863933" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=9fd6cf05ed540be1d383abf1dc788e1811638d64" released="2017-06-08" stability="stable" version="0.9.8">
+        <manifest-digest sha256new="DV5LVV5S2645PEEA56IOYQXTUP5Z7O7VEVAIR3EKGMSWXW4VIDDQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.8/terraform_0.9.8_windows_amd64.zip" size="32452706" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=5fde5d79336901c9402eca5f1eb3b9a49c5aa933" released="2017-06-08" stability="stable" version="0.9.8">
+        <manifest-digest sha256new="P2VUORFP3TFCBKWYOPFP3QG62FEEBP2EIXFRALIZJO5NLK4SMR6A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.8/terraform_0.9.8_windows_386.zip" size="28861508" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=d3230934776c01a9861b67280fb77feea4ef4544" released="2017-06-26" stability="stable" version="0.9.9">
+        <manifest-digest sha256new="GJEA6K4EXEDNUYU45VOMXFJIHJY2LNXF3MI4PTQ6SDZNLORSSIAA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.9/terraform_0.9.9_windows_amd64.zip" size="32453536" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=89f8406d6bdc4218ec6822f1fd482b4a68667311" released="2017-06-26" stability="stable" version="0.9.9">
+        <manifest-digest sha256new="JF5CQ6EVCAYODH2BNLA3RP7V5ATA7CGAF2LSMQ2N2NZI5YDNBC4Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.9/terraform_0.9.9_windows_386.zip" size="28863176" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=d72663b5ccd9d603e99e57eeefaf4797aa92df39" released="2017-06-29" stability="stable" version="0.9.10">
+        <manifest-digest sha256new="COWAZQRUSVPRMODZKFZ24N3RUES3DBDVN2JSR36TGS4ZSV6RWX2Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.10/terraform_0.9.10_windows_amd64.zip" size="32453023" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=4bd3ec0e7d4fdba3b7249bd67e4754dcb8a011ea" released="2017-06-29" stability="stable" version="0.9.10">
+        <manifest-digest sha256new="2MMNRRANVQ5FNENK5HXBQMC7B6UP5AGC5APYXMT5TN5IT42USKNQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.10/terraform_0.9.10_windows_386.zip" size="28863547" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=796a1d8bf71794d3f2e2b31e4a719107bc025b9f" released="2017-07-03" stability="stable" version="0.9.11">
+        <manifest-digest sha256new="UHN3BMODMPBJB2DTJE7XSAQOAFWAY2JJP3N5NBU4ZO3UC45W7EBQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_windows_amd64.zip" size="32452237" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=2af25f325aedd0497f576a4ff8e00579ea4025ae" released="2017-07-03" stability="stable" version="0.9.11">
+        <manifest-digest sha256new="SL3W7HNUWUSISMKQCGAXNVOQDXPAYJUFWFBYU5TTU7SGA7ZMS5EA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_windows_386.zip" size="28862059" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=63e38ec6ab418364a0ea10208fcac801f10193a6" released="2017-08-02" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="36GDG2475OAOPFNH7BN5VVNRPUEZ4FJREQFYHCR6B6RDOVQFKB5A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_windows_amd64.zip" size="12316407" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=0b34e8a42c2a90efa5bdb209901bb76eb80b3575" released="2017-08-02" stability="stable" version="0.10.0">
+        <manifest-digest sha256new="OP5FPS4EKZV65LO44JLZB5QYAT6YRM2SV3BTZW6L7AYLGSRNNQXA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_windows_386.zip" size="11142396" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=28df19f16ddf549a0c9a4c093a933dbebca23145" released="2017-08-15" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="PP275U3TBK3IODBS5WHVZ2AXRWFYSBQEEJZWB23GFHVU4JDILK2Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.1/terraform_0.10.1_windows_amd64.zip" size="12514794" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=05c4454985d902ad88b4094004a024c218ec0393" released="2017-08-15" stability="stable" version="0.10.1">
+        <manifest-digest sha256new="5VPAELCVCA6NQ55SQ7UK4IZTENMQNLFBHQ6AP6DXOSVPYRR4NGMA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.1/terraform_0.10.1_windows_386.zip" size="11328463" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=7907ff9728f1716c5d8c67b6b9468fe5d9e8b375" released="2017-08-16" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="VJY62TTHNJ6DNETQO4IAWCW5BF32WTNTKUG7LKHCU53FTFA3YL6A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.2/terraform_0.10.2_windows_amd64.zip" size="12512576" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=34c9d0822dbb7d57078d3eccc1ff51aef4f65c97" released="2017-08-16" stability="stable" version="0.10.2">
+        <manifest-digest sha256new="RDCLDQTCCSAXPFNAT2JRF4SK5VII2MX7PHEEQ7J53ID3K5I26UUA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.2/terraform_0.10.2_windows_386.zip" size="11326835" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=e493b9996fb8f23a0429f529b48332f06302e8cc" released="2017-08-30" stability="stable" version="0.10.3">
+        <manifest-digest sha256new="QDQOP2NAR2AZDUV3AJCSRKI3HL4UIY7XEK5UEDY26RGFANYKLZLQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.3/terraform_0.10.3_windows_amd64.zip" size="13153055" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=a2b4b0be2d3f4d54c6bf8c45bdaa191ba2b6a319" released="2017-08-30" stability="stable" version="0.10.3">
+        <manifest-digest sha256new="WPNMFSRIBQ7L4MNYY7W3TFOBYQYWJ3T6WXYBK4BJ7J6KIKDDIRGA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.3/terraform_0.10.3_windows_386.zip" size="12040279" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=ff444a6fa37efba92c80dd2a1e9abc1f746f9a95" released="2017-09-06" stability="stable" version="0.10.4">
+        <manifest-digest sha256new="C66UNWXAJFRQE3E4YN3P3FJXAJWJ42Z6QFIWGYBSJ2UIDFRTWEVQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.4/terraform_0.10.4_windows_amd64.zip" size="13511957" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=e29db3d7defd4e211667b54e6e51596be0fc96ec" released="2017-09-06" stability="stable" version="0.10.4">
+        <manifest-digest sha256new="V475EV4XXPNLVTQX6G7RBV34X3L2AWSAGRAK3LEVHIYPVK2CUWTQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.4/terraform_0.10.4_windows_386.zip" size="12365281" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=d6ffe03a80b6358448a5cd42dced1abab1e599bb" released="2017-09-14" stability="stable" version="0.10.5">
+        <manifest-digest sha256new="W7DZZKU422TTK5UUNJPKYQYSRUU5GTNJM7TPFRGECBXRPUAT4RMA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.5/terraform_0.10.5_windows_amd64.zip" size="13513965" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=c88072e778a4bfca3ba3a7082651bcbf922c30b9" released="2017-09-14" stability="stable" version="0.10.5">
+        <manifest-digest sha256new="E3F25NE6TMKYXQNPFWK54P4EVEH7JYIIVO3RZDPOIKJAXFTYMKDA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.5/terraform_0.10.5_windows_386.zip" size="12366523" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=2e8367989c0efe777eeedd0dfe065da4f719455b" released="2017-10-02" stability="stable" version="0.10.6">
+        <manifest-digest sha256new="FK2WTQSBXHWM3I3KFN2YXIIMZWOZJ6LV7LJ3N5HK2BFD5CEJM7DQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.6/terraform_0.10.6_windows_amd64.zip" size="13518252" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=fc1876909c730d0197c33157e39cbdc94fe3da55" released="2017-10-02" stability="stable" version="0.10.6">
+        <manifest-digest sha256new="MFSUE6OXZ4DBUW5NJDY4EXZ7FFUMJ3TERHXNU2JXYCGZNT5JE35Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.6/terraform_0.10.6_windows_386.zip" size="12372559" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=b7395a7e6add0c6a31579a406c1374c50bc8aba8" released="2017-10-02" stability="stable" version="0.10.7">
+        <manifest-digest sha256new="XVTPEBPJTFKSU3EC7XJG6RKYQAKRJZLFYO277QTWG2RB5VQZ3HGA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_windows_amd64.zip" size="13538353" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=1d769b5624999ae82990c03281d4b5f01b8ec058" released="2017-10-02" stability="stable" version="0.10.7">
+        <manifest-digest sha256new="ADGHQRSXYA4DKBCZXJT33ALOA2QU4YEYYZDA5MXPWO7OXZMCKMZQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_windows_386.zip" size="12383009" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=57f391fc5d7d009d07e349858f1d260c70f87ec7" released="2017-11-02" stability="stable" version="0.10.8">
+        <manifest-digest sha256new="FR6FT4YW2DUAFYXCOMGVRNCD335GGANPUS7JXUSTIGHKB33AO6CQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_windows_amd64.zip" size="14523574" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=9207ae20a4b8f0e2afe6154e0d8a2fc2b8614104" released="2017-11-02" stability="stable" version="0.10.8">
+        <manifest-digest sha256new="PE2AC2DXX7TIZVJUGKP36TOSXYGH6RAIBPRV5AD5QBE2QY3Z2VIQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_windows_386.zip" size="13284256" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=5c983dbeccee7a32bad636e26f1b455cb91b347d" released="2017-11-16" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="HGAIDK5VBKQJVMWP7IJYL36IQNEY2JPMHUGOJU3YITFTPUDRVODQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_windows_amd64.zip" size="14741385" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=696434f4a293b97c5a444071a28d19402dd49017" released="2017-11-16" stability="stable" version="0.11.0">
+        <manifest-digest sha256new="YDHRIJ5KIHUEKRDKXY26R7FQJQ4PEH3ZLAVPKPSLZPJXRWOU7V3A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_windows_386.zip" size="13484232" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=ca170a444c6b4401527705e923be604457179855" released="2017-11-30" stability="stable" version="0.11.1">
+        <manifest-digest sha256new="OOLIVWZN3FOBYTMIJ3JQBZNU2S45BSUHIO7CM7KR76FM5QZQESSQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.1/terraform_0.11.1_windows_amd64.zip" size="14744983" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=7e3fe5c65e5aaa2a8667f10c51af735c068e8668" released="2017-11-30" stability="stable" version="0.11.1">
+        <manifest-digest sha256new="NFJGCQSR4SJUOUTM5HZGWTNBXF4H4LI2FAXPRAQYBRJ52A2CBFOA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.1/terraform_0.11.1_windows_386.zip" size="13482987" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=0c2b93cc6eafc01e1a5368c791f7133c7d6d577d" released="2018-01-09" stability="stable" version="0.11.2">
+        <manifest-digest sha256new="XAH2PXXIXI7JNCCBGETV4RK2YXMKFTV4YYCOEP5LE7TOFBXF7DBQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_windows_amd64.zip" size="15335169" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=5dc2aeca057f777df5099c8e2a21786315b6d148" released="2018-01-09" stability="stable" version="0.11.2">
+        <manifest-digest sha256new="O3VDEUTFU7QKQEYOTSONY6VHTLLLI2WFWS6DN5KXHU3EQN5XAJXQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_windows_386.zip" size="14011826" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=1a388af172822f4e8321ce2b7a3f58dfbcaf5ad2" released="2018-01-31" stability="stable" version="0.11.3">
+        <manifest-digest sha256new="2FBSWBTVC3UMYJP5F22R6XXRYTUZ4IPIBMGW4FTLPCLFORJA2AJA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_windows_amd64.zip" size="16497828" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=ee34aad2c802001ec0b87f7c9fe142eb4bc30ff4" released="2018-01-31" stability="stable" version="0.11.3">
+        <manifest-digest sha256new="PFA7NCTQ4R2TLMQBR7MQV6CWETWK34H6VA55FLWVAC5JPTTTOHXQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_windows_386.zip" size="15067168" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=d20f57c93ad28cedb30083c18f3027a4401e0ea5" released="2018-03-15" stability="stable" version="0.11.4">
+        <manifest-digest sha256new="TUZGUJ65ZT2EKDBZTF6NWQVXUP3RKL2W3JDTVRQVOB4P42C7ZGEQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.4/terraform_0.11.4_windows_amd64.zip" size="16556953" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=6e3314ba9516351352db62ca9b93a23d257815ec" released="2018-03-15" stability="stable" version="0.11.4">
+        <manifest-digest sha256new="E2YMAL5MTUYNXVZ2QDQTPXBSGVT2MNRXCWIKVWTGMTYXVZLC54YA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.4/terraform_0.11.4_windows_386.zip" size="15409601" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=94992582f460c1d359fca2f299d699ab1581f6dd" released="2018-03-21" stability="stable" version="0.11.5">
+        <manifest-digest sha256new="RLJVVLT4VYO2URONJ7TZGBRIHQ24UDVQLO7GCIELIMFX3WFFE7CA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.5/terraform_0.11.5_windows_amd64.zip" size="16561534" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=a2fc3cc122e3aa1edca5c054651421dbf9e380eb" released="2018-03-21" stability="stable" version="0.11.5">
+        <manifest-digest sha256new="CUPXACU4RCNKKBWYAXHNBYYBHMZIBVJI27T7U6SNI7VZVTRVNGUQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.5/terraform_0.11.5_windows_386.zip" size="15410882" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=f2748475413ce4ed1990c6b668a59ac5d0d12454" released="2018-04-05" stability="stable" version="0.11.6">
+        <manifest-digest sha256new="PP6BSMCERY5RQ2VPFPWNJCM7HDXO7U56SVYTLNWERFJT3WVDIAQA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.6/terraform_0.11.6_windows_amd64.zip" size="16572682" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=e5db3b2bad7561ceffec85fd15e32a9288cdad9f" released="2018-04-05" stability="stable" version="0.11.6">
+        <manifest-digest sha256new="FFXQ6I2J3S2ZSSJVLTVGYAGXNI54IU4P4SWXERAJTZXTJ3EOILBQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.6/terraform_0.11.6_windows_386.zip" size="15420268" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=65a6b06042edb9fc40cfa977ed3ca0e5f991bde6" released="2018-04-10" stability="stable" version="0.11.7">
+        <manifest-digest sha256new="V2IL6VTAFPH7FUDL4JFSJOZGOMRGK3QRNTIGMIFPUM47STV67CLA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_windows_amd64.zip" size="16576586" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=466eaa72ad423c1e1b8869682b127825a69e1031" released="2018-04-10" stability="stable" version="0.11.7">
+        <manifest-digest sha256new="MO5ICHFCKVMXAROFE4JOZSDJJZDWMHEJBROFYTCERMKVPBWKUDLQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_windows_386.zip" size="15427145" type="application/zip"/>
+      </implementation>
+    </group>
+  </group>
+
+  <entry-point binary-name="terraform" command="run"/>
+</interface>

--- a/hashicorp/terraform.xml.template
+++ b/hashicorp/terraform.xml.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Terraform</name>
+  <summary>write, plan, and create infrastructure as code</summary>
+  <description>Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.</description>
+  <homepage>https://www.terraform.io/</homepage>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/hashicorp/terraform"/>
+
+  <group license="Mozilla Public License 2.0">
+    <group>
+      <command name="run" path="terraform"/>
+      <implementation arch="Linux-x86_64" version="{version}" stability="stable" released="{released}">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/terraform/{version}/terraform_{version}_linux_amd64.zip" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" version="{version}" stability="stable" released="{released}">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/terraform/{version}/terraform_{version}_linux_386.zip" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" version="{version}" stability="stable" released="{released}">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/terraform/{version}/terraform_{version}_darwin_amd64.zip" type="application/zip"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="terraform.exe"/>
+      <implementation arch="Windows-x86_64" version="{version}" stability="stable" released="{released}">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/terraform/{version}/terraform_{version}_windows_amd64.zip" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" version="{version}" stability="stable" released="{released}">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/terraform/{version}/terraform_{version}_windows_386.zip" type="application/zip"/>
+      </implementation>
+    </group>
+  </group>
+</interface>

--- a/hashicorp/vagrant.watch.py
+++ b/hashicorp/vagrant.watch.py
@@ -1,0 +1,5 @@
+from urllib import request
+import json
+
+data = request.urlopen('https://api.github.com/repos/hashicorp/vagrant/tags').read().decode('utf-8')
+releases = [{'version': tag['name'].strip('v')} for tag in json.loads(data) if not str.startswith(tag['name'], 'v0.') and not str.startswith(tag['name'], 'v1.')]

--- a/hashicorp/vagrant.xml
+++ b/hashicorp/vagrant.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/hashicorp/vagrant" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Vagrant</name>
+  <summary>tool for building and distributing development environments</summary>
+  <description>Development environments managed by Vagrant can run on local virtualized platforms such as VirtualBox or VMware, in the cloud via AWS or OpenStack, or in containers such as with Docker or raw LXC.</description>
+  <homepage>https://www.vagrantup.com/</homepage>
+  <needs-terminal/>
+
+  <group license="MIT License">
+    <group>
+      <command name="run" path="vagrant"/>
+      <implementation arch="Linux-x86_64" id="sha1new=c8654bf4368312906dde2c44e25a71a3eef05910" stability="stable" version="2.1.0">
+        <manifest-digest sha256new="WALC62RALTJRTDRETH2TE4V75SZM4PBT74VDLJOC7J3NMZUU7TAQ"/>
+        <archive href="https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_linux_amd64.zip" size="32698046" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=b8d2bbf760634443f6e4cd1578f22eaf00e6974f" stability="stable" version="2.1.1">
+        <manifest-digest sha256new="3NQFJYB2HV6GT7QDYPNRORPAABRNRERD2GJRSO24HCZEPWIGBTJA"/>
+        <archive href="https://releases.hashicorp.com/vagrant/2.1.1/vagrant_2.1.1_linux_amd64.zip" size="32698623" type="application/zip"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="bin/vagrant.exe"/>
+      <implementation arch="Windows-x86_64" id="sha1new=b7e4ad1df1e5d677dc4069d4f89cdfb09951dbb5" stability="stable" version="2.0.0">
+        <manifest-digest sha256new="F4GWQTU4D5QHSERT4HDQ2PC7XKZVXJIANLE3IVJUMUJBLLURGJQQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.0/vagrant_2.0.0_x86_64.msi" size="242876416" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=e62a28d0579064bbe6d6a12f37566b6fb1761df7" stability="stable" version="2.0.0">
+        <manifest-digest sha256new="73LTTRCG7VBHSU5B2EELJIHHZLKFJUHOGC3UMYXTT2X7F33TKBNQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.0/vagrant_2.0.0_i686.msi" size="238850048" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=7ff93f2c9d33db30b05ee7bd944093bff0c8bf5d" stability="stable" version="2.0.1">
+        <manifest-digest sha256new="Q53MKD3CC2752QCL47FVSQCPQYJFB4C7RTJCBJX3XDVBJFDOWZSQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.1/vagrant_2.0.1_x86_64.msi" size="238100480" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=3a68366859bd3b09bb89f3eadfc5bcaa66c0e12a" stability="stable" version="2.0.1">
+        <manifest-digest sha256new="YZQVNCRVLJVZRUOK42P4JLV5UPW72BNOK5TIJECR3LL7NINVEB3A"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.1/vagrant_2.0.1_i686.msi" size="234180608" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=5901ab2a72705e5f7114501d8cb8e2f1bf0698a2" stability="stable" version="2.0.2">
+        <manifest-digest sha256new="LIONVM3WR6Z4YP2NZRX2YD6RPWYWHVQQM3MJWTGTKQEWB5ZO26YQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.2/vagrant_2.0.2_x86_64.msi" size="206331904" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=f5750a7944927960c579bca9ccab226a94914362" stability="stable" version="2.0.2">
+        <manifest-digest sha256new="SFGJQYNKW6PDDOIK5TMIIUNWD7J4EASWJZEXXH66LQA46M73O74A"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.2/vagrant_2.0.2_i686.msi" size="202420224" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=32b0583397345536b1f50d71cc7349de32392509" stability="stable" version="2.0.3">
+        <manifest-digest sha256new="66XFJZRR5NGHJWKFIWWYUXJHLLKULKYGMATAV7MBV2DOHJQ2CRXQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.msi" size="204537856" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=a6a25602b2465f281ed8c5be09259ff78a657c2d" stability="stable" version="2.0.3">
+        <manifest-digest sha256new="KCBTCVL55Z6LJBRXW3YYST6OMNA6PLAXVF3NWJRFWQJGB5GHNZMA"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_i686.msi" size="201142272" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=638b74e13f1cb9f92538a35708876b855716ec9c" stability="stable" version="2.0.4">
+        <manifest-digest sha256new="QZATXNJOEHVDBI7JSEZQQADXRUEKIU5PR5VKT4JBLP2WCRDPPJ6A"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.4/vagrant_2.0.4_x86_64.msi" size="205033472" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=f9dfb5e7d1af2de32880723d32e889f7b43e3b2c" stability="stable" version="2.0.4">
+        <manifest-digest sha256new="4UCYLWVJYSUSY2PYL3PFPJD5CXXKDLSLWAK64ZPCVVH6JYETZCKQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.0.4/vagrant_2.0.4_i686.msi" size="201719808" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=00b0169cd88a75f42ad322ded75fd3350b1d046c" stability="stable" version="2.1.0">
+        <manifest-digest sha256new="J5MDLQ6ZDCX3CGAO6MHMMUID4726UAZUJLDTGVOIMNQW2OPO6CVQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_x86_64.msi" size="205078528" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=7252492693396b2e4682d218e2b8a948d7bbdf1c" stability="stable" version="2.1.0">
+        <manifest-digest sha256new="Z7KUSCTSAYE52VOL5X2LS4LW2QUFLJCKKCLSOOUUELJL76DVHVMQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_i686.msi" size="201744384" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=c8d484e1c007ec5e903cf1f3333f476c9c642455" stability="stable" version="2.1.1">
+        <manifest-digest sha256new="EMXWCQ6UQKGYWIPLZ7LDDUUGOIER3E7RTWNZCNAQITN2Q4EDZ6OQ"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.1.1/vagrant_2.1.1_x86_64.msi" size="205099008" type="application/x-msi"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=793216244e5a964902318170b967a1365e996a5f" stability="stable" version="2.1.1">
+        <manifest-digest sha256new="ZR3X6O2XRAHKD5D2CWV5JZMWBIFIKNHRU3IXQQMGWSO3RDRPYX4Q"/>
+        <archive extract="SourceDir/HashiCorp/Vagrant" href="https://releases.hashicorp.com/vagrant/2.1.1/vagrant_2.1.1_i686.msi" size="201728000" type="application/x-msi"/>
+      </implementation>
+    </group>
+  </group>
+
+  <entry-point binary-name="vagrant" command="run"/>
+</interface>

--- a/hashicorp/vagrant.xml.template
+++ b/hashicorp/vagrant.xml.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Vagrant</name>
+  <summary>tool for building and distributing development environments</summary>
+  <description>Development environments managed by Vagrant can run on local virtualized platforms such as VirtualBox or VMware, in the cloud via AWS or OpenStack, or in containers such as with Docker or raw LXC.</description>
+  <homepage>https://www.vagrantup.com/</homepage>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/hashicorp/vagrant"/>
+
+  <group license="MIT License">
+    <group>
+      <command name="run" path="vagrant"/>
+      <implementation arch="Linux-x86_64" version="{version}" stability="stable">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/vagrant/{version}/vagrant_{version}_linux_amd64.zip" type="application/zip"/>
+      </implementation>
+    </group>
+    <group>
+      <command name="run" path="bin/vagrant.exe"/>
+      <implementation arch="Windows-x86_64" version="{version}" stability="stable">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/vagrant/{version}/vagrant_{version}_x86_64.msi" type="application/x-msi" extract="SourceDir/HashiCorp/Vagrant"/>
+      </implementation>
+      <implementation arch="Windows-i486" version="{version}" stability="stable">
+        <manifest-digest/>
+        <archive href="https://releases.hashicorp.com/vagrant/{version}/vagrant_{version}_i686.msi" type="application/x-msi" extract="SourceDir/HashiCorp/Vagrant"/>
+      </implementation>
+    </group>
+  </group>
+</interface>


### PR DESCRIPTION
This adds a feed for for the [HashiCorp](https://www.hashicorp.com/) tools [Vagrant](https://www.vagrantup.com/), [Terraform](https://www.terraform.io/) and [Packer](https://www.packer.io/).

Here is an `index.html` for the new `hashicorp/` directory:
```html
<!DOCTYPE html>
<html>
  <head>
    <title>repo.roscidus.com: HashiCorp</title>
  </head>
  <body>
    <h1>repo.roscidus.com: HashiCorp</h1>
    <p>
      HashiCorp provides tools for development and for cloud infrastructure automation.
    </p>

    <p>To add Vagrant to your <code>PATH</code>:</p>
    <pre>
      $ 0alias vagrant http://repo.roscidus.com/hashicorp/vagrant
    </pre>

    <p>To add Terraform to your <code>PATH</code>:</p>
    <pre>
      $ 0alias terraform http://repo.roscidus.com/hashicorp/terraform
    </pre>

    <p>To add Packer to your <code>PATH</code>:</p>
    <pre>
      $ 0alias terraform http://repo.roscidus.com/hashicorp/packer
    </pre>

    <h2>Available feeds</h2>

    <ul>
      <li><a href='vagrant'>Vagrant</a></li>
      <li><a href='terraform'>Terraform</a></li>
      <li><a href='packer'>Packer</a></li>
    </ul>
  </body>
</html>
```