### PR TITLE
Added new utilities

### DIFF
--- a/devel/gitversion.watch.py
+++ b/devel/gitversion.watch.py
@@ -1,0 +1,19 @@
+from urllib import request
+import json
+
+def convert(release):
+    sem_ver = release['tag_name'].strip('v')
+    if 'beta.' in sem_ver:
+        version = sem_ver.replace('beta.', 'pre')
+        sem_ver_split = sem_ver.split('beta.')
+        nuget_ver = sem_ver_split[0] + 'beta' + sem_ver_split[1].zfill(4)
+        stability = 'testing'
+    else:
+        version = sem_ver
+        nuget_ver = sem_ver
+        stability = 'stable'
+    released = release['published_at'][0:10]
+    return {'version': version, 'sem-ver': sem_ver, 'nuget-ver': nuget_ver, 'stability': stability, 'released': released}
+
+data = request.urlopen('https://api.github.com/repos/GitTools/GitVersion/releases').read().decode('utf-8')
+releases = [convert(release) for release in json.loads(data) if len(release['assets']) > 0 and not '+' in release['tag_name']]

--- a/devel/gitversion.xml
+++ b/devel/gitversion.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/devel/gitversion" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>GitVersion</name>
+  <summary>versioning when using git, solved</summary>
+  <description>Versioning when using git, solved. GitVersion looks at your git history and works out the semantic version of the commit being built.</description>
+  <category>Development</category>
+  <homepage>https://github.com/GitTools/GitVersion</homepage>
+  <needs-terminal/>
+
+  <group>
+    <command name="run" path="GitVersion.exe">
+      <runner command="run" interface="http://repo.roscidus.com/dotnet/clr"/>
+    </command>
+    <implementation id="sha1new=5c46d21ee73a5d055f295b64b47d6bfb89810724" released="2015-08-26" stability="stable" version="3.1.1">
+      <manifest-digest sha256new="I62ITQTZQDAXEBMSAJIWUDWOQKMKGNTDHAYZIOC4EZ3GZDIOMITQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.1.1/GitVersion_3.1.1.zip" size="1174161" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=fb4e4cb71127b3f6e2a20127266e24668406af56" released="2015-09-07" stability="stable" version="3.1.2">
+      <manifest-digest sha256new="RBCUZWLTLFRXQOKNFV7LBB24EF45L7FJLENTM6J4BNK4LP2IM5VA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/3.1.2/GitVersion_3.1.2.zip" size="1175217" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=41d901f8e08fca33890b8071b0878d778f6f7016" released="2015-10-12" stability="stable" version="3.2.0">
+      <manifest-digest sha256new="KNRGPV5PB4T7RKMGB6XJWVQCBSGTVWVVTVXFDZOF34QOA72RTTSQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.2.0/GitVersion_3.2.0.zip" size="1175358" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=ed7bf99fc154f2793ec3c61c088f98bf3f6f2ec2" released="2015-10-20" stability="stable" version="3.3.0">
+      <manifest-digest sha256new="3XBOA32VLD6V7YYTXB64NEB65K7E2JNKWQIBROCM5U4FX5SE5LJQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.3.0/GitVersion_3.3.0.zip" size="1178209" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=52839686b355fea9ba96db208a2ae8f2724c3591" released="2016-01-31" stability="stable" version="3.4.0">
+      <manifest-digest sha256new="OIUQOVSEJT34HVYLBUS5PQBKUUQHUA6ATLSHJP6K5N6RQV7IFGGQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.4.0/GitVersion_3.4.0.zip" size="1182540" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=8937500a589396ee1c91539291767ddc80f750bd" released="2016-04-26" stability="stable" version="3.4.1">
+      <manifest-digest sha256new="VR2BUP5BBYNLLYPYXETL6ZPUFLH7MOPXKQGZUCLQOBUVLCNLMXSQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.4.1/GitVersion_3.4.1.zip" size="1182526" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=cf9b4411aec89c4bc5c1069fc0d853d014fc8eb2" released="2016-04-26" stability="stable" version="3.5.0">
+      <manifest-digest sha256new="IYH4DFYHVOKG6B7QK2QN6WRLO7JARJWM5OJGMABB6UQRTD55YHEA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.5.0/GitVersion_3.5.0.zip" size="5523376" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=2469b0af0cf016771b827203ad75d94f690cabeb" released="2016-04-26" stability="stable" version="3.5.1">
+      <manifest-digest sha256new="MZOIM4M4RXSMT4Q3VVQFJ5ANCKZ3OYUFJVIG2XZIAOFYPCZ5EXRQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.5.1/GitVersion_3.5.1.zip" size="5523340" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=331efad2b0b0fd37a8869fa24daf86c08079f7de" released="2016-04-26" stability="stable" version="3.5.2">
+      <manifest-digest sha256new="QK5AUGGI525NBFTABLEZ5OFFA6UT7DX63OCVVYRVSE4CYQGKAB5A"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.5.2/GitVersion_3.5.2.zip" size="5523181" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=0ab520cd3c3954d46e83c846aa02ab2fbf71ceee" released="2016-05-13" stability="stable" version="3.5.3">
+      <manifest-digest sha256new="YZ5OAVKTYD6KEQQZ3E57ASI4PRZAO276I3BL6JOIJZZQ4IGDRXKA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.5.3/GitVersion_3.5.3.zip" size="5524150" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=60138555098484ab4896b745e1ffd79224f956f8" released="2016-05-18" stability="stable" version="3.5.4">
+      <manifest-digest sha256new="SYMLRPWPHPBY36LMMWL77FENUHBLWGDONFJUGI6Q6FJMMOOXYOFA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.5.4/GitVersion_3.5.4.zip" size="5524022" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=9320f3123ac988b887ccafc74eb7d5e0d56d1d90" released="2016-07-10" stability="stable" version="3.6.0">
+      <manifest-digest sha256new="CDBIDHB3G3KMBC2GP5O4HRKVQ3NPNOD5SJHOTMWJTNRCQT6O7JYQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.6.0/GitVersion_3.6.0.zip" size="6025779" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=41c2d7a8f45fda63d52b73709a0b9c4d00e39c87" released="2016-07-17" stability="stable" version="3.6.1">
+      <manifest-digest sha256new="3BAT7ITNDRDTPWL3NBM27T5UZ37W4QWCG5Y7WBXWIB5HWXZRJKMA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.6.1/GitVersion_3.6.1.zip" size="6027277" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=57edba5703876081e6e9b52270a66ae0a0118bc2" released="2016-07-26" stability="stable" version="3.6.2">
+      <manifest-digest sha256new="FBB7OU4QXTE4CXNWLESY5C6SNAKACF6TXJYSTZLGITNZB7FMYGOA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.6.2/GitVersion_3.6.2.zip" size="6027605" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=e3624fa489aecec3e058544bee6670e1e7fcc2c7" released="2016-08-29" stability="stable" version="3.6.3">
+      <manifest-digest sha256new="UP3XIYXEXBH6HFALPQCRPR72PVL7EFB2BGHHVHHWQHAJ34ZZO46Q"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.6.3/GitVersion_3.6.3.zip" size="6027596" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=c5c3cc82989873aa0ddd5460c4a6f1eb9d208cfb" released="2016-09-04" stability="stable" version="3.6.4">
+      <manifest-digest sha256new="4USEDJAR26BHNFQZFM4QNZ5L32NTANTVAEQULF3DGSRUDQ77U6VQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.6.4/GitVersion_3.6.4.zip" size="6028084" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=67060fce11f53cadd40382815e556638244ebef6" released="2016-11-27" stability="stable" version="3.6.5">
+      <manifest-digest sha256new="PPTGRTM4JZQJG7NEF4THNAL3ETKPZQODHAG47MXUAIAUFXR3TERA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v3.6.5/GitVersion_3.6.5.zip" size="6155943" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=ee3626e963112232f234769865d03c65705b857d" released="2016-07-20" stability="testing" version="4.0.0-pre1">
+      <manifest-digest sha256new="LBYFZQXASZ4PK3TQQQ3R7TTGRUF34MQHZSXCQORAXDAYK5PW2H4A"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.1/GitVersion_4.0.0-beta0001.zip" size="6029161" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=291f3c96f6e98ce80a0865416d1b584a0e924a10" released="2016-07-26" stability="testing" version="4.0.0-pre2">
+      <manifest-digest sha256new="7Q5Q26TUBHFKPEP4KYWAHKPXNI4PZK4SKM46QW43XB3SWROUSDVQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.2/GitVersion_4.0.0-beta0002.zip" size="6029468" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=6ca25eddcdd84e7b767bc85f2cca71067a269ab8" released="2016-08-11" stability="testing" version="4.0.0-pre3">
+      <manifest-digest sha256new="EKFQRLNROBSXOYWTZWDKNY3RGVOCZMUH37A2CRJYQG2AHA5JWULA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.3/GitVersion_4.0.0-beta0003.zip" size="6029503" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=c643bc5e4677f034cb31faefd11c7303a61f5df5" released="2016-08-12" stability="testing" version="4.0.0-pre4">
+      <manifest-digest sha256new="TN7H27NXS6CITG5ZKFHMB7NXMNZBXPR2QQ3OPEYYKMB3PZUMB4OQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.4/GitVersion_4.0.0-beta0004.zip" size="6030634" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=cfa210256ec1941a9d943553ecffcc6cff55e22c" released="2016-08-15" stability="testing" version="4.0.0-pre5">
+      <manifest-digest sha256new="CZH27XTKL527QNGVCNKZS36F5IJUIKJ64Q3SMNBTGYOZYM452F4Q"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.5/GitVersion_4.0.0-beta0005.zip" size="6031139" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=be33abd46e5f2c44afe329dbe309abfbda507bc5" released="2016-09-04" stability="testing" version="4.0.0-pre7">
+      <manifest-digest sha256new="QX6UQK6DMCJIQKXQFYOOKJJ4NMLFBS7SHSZLH77A23PNPERTFLDA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.7/GitVersion_4.0.0-beta0007.zip" size="6033406" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=8f6fe5c25f2d5cdb3ad007d6278f5b4ae80de134" released="2016-11-27" stability="testing" version="4.0.0-pre8">
+      <manifest-digest sha256new="63UZCWRVTCPAQ6Z6UDOCPIZNB2AVJPLES6OLSPNCQ62ZKF5RI7ZQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.8/GitVersion_4.0.0-beta0008.zip" size="6165701" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=6e2ba5d533be2a411931cf2c38ca2c47d4434b73" released="2016-11-28" stability="testing" version="4.0.0-pre9">
+      <manifest-digest sha256new="7OAB7NOW43QGEPUM74FJ6JWAIFYNWUQF3LAQ4RMTNXSBEUOJQLHA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.9/GitVersion_4.0.0-beta0009.zip" size="6167007" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=b88d76a6e40ed7a44e721059330ba5e1b07f46fd" released="2017-02-25" stability="testing" version="4.0.0-pre10">
+      <manifest-digest sha256new="EFFHDNRPDDIRKRKJ6GA4KFEBQOH7UXT6EOYNWGFVPDRUMLLVMDAA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.10/GitVersion_4.0.0-beta0010.zip" size="6170500" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=a5f330348ada0eb479dd230af82caaa2278b5fba" released="2017-02-26" stability="testing" version="4.0.0-pre11">
+      <manifest-digest sha256new="ZGMWQTWXAK3GM7NXYGYIQEMJDAN3YGJ5EDLJIDR2FP5454ZF7JDA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.11/GitVersion_4.0.0-beta0011.zip" size="6170595" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=2d47264884eabc6e806ba318d68ebceddb2328f8" released="2017-05-17" stability="testing" version="4.0.0-pre12">
+      <manifest-digest sha256new="MZ46W7NNLQSGFS6PVAI7A2Z6UYQ6BDW7UDLQDKLD6KRDHM3OTG6Q"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.12/GitVersion_4.0.0-beta0012.zip" size="6170521" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=61f3dcded40f08e08d953da11f58dd2ac1fab26e" released="2017-12-05" stability="testing" version="4.0.0-pre13">
+      <manifest-digest sha256new="AWV4SAZR36RMJHPZ75BCLFENMMZWHVEPZ2UTPD7ZCPPOQJKH4MXQ"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.13/GitVersion_4.0.0-beta0013.zip" size="6172795" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=b136b60860de70c7e3453de9bd9662e49872bd51" released="2018-08-21" stability="testing" version="4.0.0-pre14">
+      <manifest-digest sha256new="AH7H5V5QJ2YWVYEADXZHG45FLXDKXYGFYSCL3TRTVYDX2LI7L3MA"/>
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v4.0.0-beta.14/GitVersion_4.0.0-beta0014.zip" size="5996644" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <entry-point binary-name="GitVersion" command="run"/>
+</interface>

--- a/devel/gitversion.xml.template
+++ b/devel/gitversion.xml.template
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>GitVersion</name>
+  <summary>versioning when using git, solved</summary>
+  <description>Versioning when using git, solved. GitVersion looks at your git history and works out the semantic version of the commit being built.</description>
+  <category>Development</category>
+  <homepage>https://github.com/GitTools/GitVersion</homepage>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/devel/gitversion"/>
+
+  <group>
+    <command name="run" path="GitVersion.exe">
+      <runner interface="http://repo.roscidus.com/dotnet/clr" command="run"/>
+    </command>
+    <implementation version="{version}" released="{released}" stability="{stability}">
+      <archive href="https://github.com/GitTools/GitVersion/releases/download/v{sem-ver}/GitVersion_{nuget-ver}.zip" type="application/zip"/>
+    </implementation>
+  </group>
+</interface>

--- a/editors/atom.watch.py
+++ b/editors/atom.watch.py
@@ -1,0 +1,10 @@
+from urllib import request
+import json
+
+def convert(release):
+    version = release['tag_name'].strip('v')
+    released = release['published_at'][0:10]
+    return {'version': version, 'released': released}
+
+data = request.urlopen('https://api.github.com/repos/atom/atom/releases').read().decode('utf-8')
+releases = [convert(release) for release in json.loads(data) if not release['prerelease']]

--- a/editors/atom.xml
+++ b/editors/atom.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/editors/atom" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Atom</name>
+  <summary>the hackable text editor</summary>
+  <description>Atom is a hackable text editor for the 21st century, built on Electron, and based on everything we love about our favorite editors. We designed it to be deeply customizable, but still approachable using the default configuration.</description>
+  <homepage>https://atom.io/</homepage>
+  <icon href="http://0install.de/feed-icons/Atom.ico" type="image/vnd.microsoft.icon"/><!-- TODO: Export icon -->
+  <icon href="http://0install.de/feed-icons/Atom.png" type="image/png"/>
+  <category>Development</category>
+  <category>Utility</category>
+
+  <group license="MIT License">
+    <implementation arch="Windows-x86_64" id="sha1new=4facbc0789fac72b53313cffea36fde538bf3352" main="Atom.exe" released="2018-03-08" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="N5X4JQUBDPTN45PAD23ESSBPIYO2UEMKR6R4KX7XKUSKTX3I6CXQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.24.1/atom-x64-windows.zip" size="139769147" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=de62e3c9a1b7652ac6e0b6b06e5ea45701ed07cd" main="Atom.exe" released="2018-03-08" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="WS3TNGYT2MPIFE3JUM7ZRIQIXFS73JA4BGQPME6NJWGE2RLVQHFA"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.24.1/atom-windows.zip" size="128967432" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=bfa6821cd6dd5de20a1c4082bbcd85ff63216af2" main="atom" released="2018-03-08" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="V6UHK2RWGYNHCHKZGSGZBCRHBG3M2IMMNI64JMUKYE32M5XZPVNA"/>
+      <archive extract="atom-1.24.1-amd64" href="https://github.com/atom/atom/releases/download/v1.24.1/atom-amd64.tar.gz" size="130525774" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=34c62cd07b6dbbfd58ea001da881dcd4e8e1091e" main="Contents/MacOS/Atom" released="2018-03-08" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="2VZQTMZ3L77WMTT43RETTJSWHC6562JLYVJM3CJSQZDMZUI4I3NA"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.24.1/atom-mac.zip" size="135583736" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=0c9e5f6b00d2a4535c19d0f403294c546c0460c6" main="Atom.exe" released="2018-03-15" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="3WWHXXZ2UUGM46GQFTYAOPJ7UWA2POJYZ4JLHR3QW3IQXGVSK4CQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.25.0/atom-x64-windows.zip" size="149313406" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=5ad1832aefed65c012c2c1cc904a16d3f7e99d27" main="Atom.exe" released="2018-03-15" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="SMIRNIPXO2C4I6P2QFWQC5BMDPCLYNEAIQ73QOLUVNUERP2Y6K3Q"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.25.0/atom-windows.zip" size="138248730" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=ee2fc6b1688455755313341db5f99102f3fd4ab2" main="atom" released="2018-03-15" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="BWC3K4VSIHYOB7OVD3BU76TM66VFO37TC7SURPZ5JN2W46RLSSYA"/>
+      <archive extract="atom-1.25.0-amd64" href="https://github.com/atom/atom/releases/download/v1.25.0/atom-amd64.tar.gz" size="140243807" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=879af35f7f1a574e2c5ea6e2cb375e72ffe5ae67" main="Contents/MacOS/Atom" released="2018-03-15" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="4ZXCP4UQQHHF7FCODILOJRS3X377JSDVVFK4GQJP4T2BX73IWOZQ"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.25.0/atom-mac.zip" size="145620747" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=c3bd309ff6f01b2b89acf5f1f086926531d13a85" main="Atom.exe" released="2018-04-05" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="TSOPVDH7THCJDVDX5NKNVTJFUGF4NYBVK5QGXEQBJ6J6QMULS2PQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.25.1/atom-x64-windows.zip" size="149328876" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=761e1f9584edad8f941503522e2d7b64c10aba9d" main="Atom.exe" released="2018-04-05" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="YDBP6HP23HWSYRKQDGK2PNXPPTMVDQHA22ENREXCZBHNNCWVYSXQ"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.25.1/atom-windows.zip" size="138261326" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=3078252401399c96c7249104bbd1ca43b391a27b" main="atom" released="2018-04-05" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="ZYRA4GDQFZSJE7ERCCI7W7WU3X33V3GLB5LOMBO5BZPPBMQGFT4Q"/>
+      <archive extract="atom-1.25.1-amd64" href="https://github.com/atom/atom/releases/download/v1.25.1/atom-amd64.tar.gz" size="140245258" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=cd5cd956eed3171e4275cac180eb7a2387005067" main="Contents/MacOS/Atom" released="2018-04-05" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="SO44SV3NO5TEECMFL3YBHJFLA2QDPPPXS4LLBB5RIVOEMNHPE33A"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.25.1/atom-mac.zip" size="145615234" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=f7ce89f02bb2c88d92e4ee90225edae9e6be900e" main="Atom.exe" released="2018-04-18" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="FYODVL33Q2TAKT2QOQAYWLIAJDEZFKLWJLROA32LY6ONNEZFKZKQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.26.0/atom-x64-windows.zip" size="150186811" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=450bc54e9ee0e729b3e1bef3f31ff18a3b079711" main="Atom.exe" released="2018-04-18" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="RIEF6OPKJLZRXNZ5OC6EFRUCVOG7VYWYCBNPTF7VD4E4LNI6D2ZQ"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.26.0/atom-windows.zip" size="139073703" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=9298eea00c6162ccc70581783eefec1b0a49d89e" main="atom" released="2018-04-18" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="YRBO5UHR6HVYQM4UNTC3FSS56DJ2ADI5B2PZEQAFKV7S3UYMY2NA"/>
+      <archive extract="atom-1.26.0-amd64" href="https://github.com/atom/atom/releases/download/v1.26.0/atom-amd64.tar.gz" size="141212838" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=5e9409f7064373c1ec1a453ff302f125590c6790" main="Contents/MacOS/Atom" released="2018-04-18" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="JNWUVOG2R7S2YUWQLUBFDZRJTVCYMEVOSTXVC7QGYJJFJLBG7STA"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.26.0/atom-mac.zip" size="146411927" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=bc845ad4c6645f8c591ecd9c1c47ebf37858b32e" main="Atom.exe" released="2018-04-26" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="7XQRXFMIZRCFKAOSIIPPKUSH4LMVHUFLA4AYX6ERZU7RSHDYXL2A"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.26.1/atom-x64-windows.zip" size="152156539" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=5558b15bf2feada3da8d1f069747825b4985e4df" main="Atom.exe" released="2018-04-26" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="WVC2TUYDXPHYLVEI2KY332WR7EIGRFTA3KZCJG53U3AJ4UQXZTBA"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.26.1/atom-windows.zip" size="141048961" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=52da5529da5bc53f63562c916bbac571a8094592" main="atom" released="2018-04-26" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="4PK3OJF2ZNJTVOCX5UYJ6VT3HHWNDZEFIJLNTLBXBLPSXBEPKL4A"/>
+      <archive extract="atom-1.26.1-amd64" href="https://github.com/atom/atom/releases/download/v1.26.1/atom-amd64.tar.gz" size="141217570" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=6b5936f8f4a0218f2be6eb3f69af96f5c859c035" main="Contents/MacOS/Atom" released="2018-04-26" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="UM7ONZ4OPUUAZHWCQVJ6JEETTIWPWO4HCQ66C5DSAACAHOM7N6KQ"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.26.1/atom-mac.zip" size="146416545" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=d733bc1df07b5b6accba8860a454bf405194528e" main="Atom.exe" released="2018-05-15" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="6UHS4KNN7QAUUTK4DYGERXJ5XH2TYMPGN5T2CH72HWHVKZ6ACYJQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.27.0/atom-x64-windows.zip" size="153503518" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=b24d3d445749aa5b809472cedd0828c82e160cf7" main="Atom.exe" released="2018-05-15" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="5EUA2FQGDLERFSXBUMWBKMJ6VXMNQJTPUEOQUX4TTSTOEWQN27JQ"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.27.0/atom-windows.zip" size="142390834" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=83e2c8d1b62ebb2f5f3212ffd770fd98aedabf58" main="atom" released="2018-05-15" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="ZS3HGHAZHCVPNSJGD2WC6OHOB2ZJYEMYU4EDCVFTQ5IWWG765ZJA"/>
+      <archive extract="atom-1.27.0-amd64" href="https://github.com/atom/atom/releases/download/v1.27.0/atom-amd64.tar.gz" size="142008772" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=2496d16b03dc412ff6f96133cb1bcb784400e7e8" main="Contents/MacOS/Atom" released="2018-05-15" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="2PPZCJWCU625VO37JXGEDGTDTZZ3E4GZDQ3PBFQIVY7PCAIAKODQ"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.27.0/atom-mac.zip" size="146908125" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=8b0aacae0d5ffa45956f4a92d8a721fa74b2ceb9" main="Atom.exe" released="2018-05-21" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="K6TESW5MZRAJMIEPFXHVPMGGGV2CELDHSLMYVGD3M23DUZOMJILQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.27.1/atom-x64-windows.zip" size="153602972" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=81419ea58437e40e06175d4caeba5a466f201115" main="Atom.exe" released="2018-05-21" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="BLAENQHZNLLAELS5MPTDONGRY7SQVYEWD3K47VPW7GI5I6CNYWUQ"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.27.1/atom-windows.zip" size="142554500" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=8f65ed67c77d65ea7f0c31461819bb15161a7dd8" main="atom" released="2018-05-21" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="RDKH7A3ZODMJ5PHVTSNDFEMA544A7FMCUNCJTZLVNBCJRHJLUGLQ"/>
+      <archive extract="atom-1.27.1-amd64" href="https://github.com/atom/atom/releases/download/v1.27.1/atom-amd64.tar.gz" size="141976250" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=bdada19690dabd169f4ba93f46abf5e0e034fcd1" main="Contents/MacOS/Atom" released="2018-05-21" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="DKS3E64J2WHIUJVXNCBWUQDPQ34ANP62EVYKNQ2RZCVKHK6A3OFA"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.27.1/atom-mac.zip" size="146911224" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=675df678d49df2a9d523679aeb9bd2b062a2acdf" main="Atom.exe" released="2018-05-31" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="ELMH4TFYWGLQ4S5TWVRMDS2BHHH4OZFR466DMGZ5U3J7SC45JRKQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.27.2/atom-x64-windows.zip" size="153659871" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=51f217b96fc610fc3b5063042a538ad365ba2c23" main="Atom.exe" released="2018-05-31" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="NEABRCRI6GYUUDOIUHMQ3UIJDTEI5WLFVHEPA5JDDCS5GRA4WXFA"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.27.2/atom-windows.zip" size="142619556" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=5d5bc950c645ad6267faf656ff4ddb664815beab" main="atom" released="2018-05-31" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="GKLSTH6RBBDY5VIOY74VE75JRDJB44BUDRF67TSSVUIBARX2CKSQ"/>
+      <archive extract="atom-1.27.2-amd64" href="https://github.com/atom/atom/releases/download/v1.27.2/atom-amd64.tar.gz" size="141964433" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=4da86d3fd7bfeb146b2b11b9ecc836264db15604" main="Contents/MacOS/Atom" released="2018-05-31" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="WN2PZINUVPQTBGZJSBOMP2OCAQ76Z5QRFUN7F57Y5JDYU7WI746A"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.27.2/atom-mac.zip" size="146891329" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=cf211324b019a2c0aee95a2a1de6f5e3f98fd828" main="Atom.exe" released="2018-06-21" stability="stable" version="1.28.0">
+      <manifest-digest sha256new="T6A7RYHJPFFOLKPO3IME2CGTFTP6JRKN2PCEW5QQ5G5R7RO67WFQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.28.0/atom-x64-windows.zip" size="148522909" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=c8e4bd163864be3322a0c17762526d0c85bdad76" main="Atom.exe" released="2018-06-21" stability="stable" version="1.28.0">
+      <manifest-digest sha256new="5LPNTLLBDHDFKL6QYFZJZD623FXPWG65SBZWHAZZUEQ7S2K5J2XA"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.28.0/atom-windows.zip" size="138358896" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=90c5ec452dd6abcc2cdb4141a1efdf3881044f8a" main="atom" released="2018-06-21" stability="stable" version="1.28.0">
+      <manifest-digest sha256new="LXKYKJI5NPAK2I2YTE7T3SO3C4LVT2HQBXN36OGXRILJ3B7YWLXQ"/>
+      <archive extract="atom-1.28.0-amd64" href="https://github.com/atom/atom/releases/download/v1.28.0/atom-amd64.tar.gz" size="138057124" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=e291a204562cf16d0cfa6c31dc5d7695c90f1689" main="Contents/MacOS/Atom" released="2018-06-21" stability="stable" version="1.28.0">
+      <manifest-digest sha256new="COLDURRP5HFORURX4JZUCB6GL2CWGNVBROXQTBIM5BPH3RNGAK3A"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.28.0/atom-mac.zip" size="146415541" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=b3b91b55b9bb31bfbc4131614b696d9af497b9bf" main="Atom.exe" released="2018-07-05" stability="stable" version="1.28.1">
+      <manifest-digest sha256new="646AOZRZL3E2GHWV5CPF27M4YIUKFLRCMR2BPOSY5QN2YBONBPJA"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.28.1/atom-x64-windows.zip" size="148531162" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=04248780f38e7204f316b9133f551ee191a48011" main="Atom.exe" released="2018-07-05" stability="stable" version="1.28.1">
+      <manifest-digest sha256new="TIK6PFHSQY2O4ZYWRY5PWDCSSXM7TOAOLJECN42A2ILQ55LMF3LA"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.28.1/atom-windows.zip" size="138370510" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=dbd6cdcfb521b3dadfc271b89b99d9387372ace4" main="atom" released="2018-07-05" stability="stable" version="1.28.1">
+      <manifest-digest sha256new="3ER53UXQP7AA5AF7V3T4FKJAUMQDQKTXZKMG73UMXPM7KODU5XTA"/>
+      <archive extract="atom-1.28.1-amd64" href="https://github.com/atom/atom/releases/download/v1.28.1/atom-amd64.tar.gz" size="138046504" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=ed14241fe0f626f8e6420ad2afc86d1eacfa72e0" main="Contents/MacOS/Atom" released="2018-07-05" stability="stable" version="1.28.1">
+      <manifest-digest sha256new="KTUDT66IXFQT4TPOPXXHOGUYJTPH7G47UBTYK4HFVGX3ZPBRI7IQ"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.28.1/atom-mac.zip" size="146417535" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=36c8b91760faf0a7dbae152393723ac89ef1faf7" main="Atom.exe" released="2018-07-13" stability="stable" version="1.28.2">
+      <manifest-digest sha256new="2YUYDLTGCAE2NUDNSBB6DQYMOLSBLOSIS3VYOU755GH7GFXLYDDQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.28.2/atom-x64-windows.zip" size="148451255" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=88937fcb08c289bd3c6827ac64eef48d6a908ec5" main="Atom.exe" released="2018-07-13" stability="stable" version="1.28.2">
+      <manifest-digest sha256new="EBPXNUAR3EHIH5KMZKXNXKQXEFXHIZ2W2VLCOBJKXIDXKMEJWO4A"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.28.2/atom-windows.zip" size="138288307" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=1994a8e891fe938154a4a79dad7b827cabb2cf5f" main="atom" released="2018-07-13" stability="stable" version="1.28.2">
+      <manifest-digest sha256new="WKVB5TRY54UWNT4F6UM65DWKHM3J7KUHY4JYZZOBK3OPSV6WHOLQ"/>
+      <archive extract="atom-1.28.2-amd64" href="https://github.com/atom/atom/releases/download/v1.28.2/atom-amd64.tar.gz" size="138076577" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=a86c44b80abef4b9ce35abcaee41f09ac12ad90b" main="Contents/MacOS/Atom" released="2018-07-13" stability="stable" version="1.28.2">
+      <manifest-digest sha256new="XEH3WFNA5N7RD6WFEAHSUS6OVUV36B3TM4ZWSC3D5C6WPKB2OUBA"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.28.2/atom-mac.zip" size="146816169" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=1d384a1634cf976b595bf9d295f5c8f5c952bfe3" main="Atom.exe" released="2018-07-31" stability="stable" version="1.29.0">
+      <manifest-digest sha256new="S2WJDNPP24XHIZGQIEIAI73GM6U6LHS5667SDKO5UQHUVW53Y2QQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.29.0/atom-x64-windows.zip" size="145013021" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=2fdece3412886f9f02ba316f84b94b4911e5967c" main="Atom.exe" released="2018-07-31" stability="stable" version="1.29.0">
+      <manifest-digest sha256new="OSS33TVFXVNGT2VAISAMSKR2QOLU7NR5VDUTUOSYSNHK3KWGMCXQ"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.29.0/atom-windows.zip" size="134833219" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=611c68458277dbca9ff723b896565ae019c28812" main="atom" released="2018-07-31" stability="stable" version="1.29.0">
+      <manifest-digest sha256new="DWNU27MJHAUXYHYLQQOP7IHU2R5HFPZEHXWL3B5SLFRRHQH6N5PQ"/>
+      <archive extract="atom-1.29.0-amd64" href="https://github.com/atom/atom/releases/download/v1.29.0/atom-amd64.tar.gz" size="138306831" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=bc3406452c661f80c8c61285f635a2ae3b394edf" main="Contents/MacOS/Atom" released="2018-07-31" stability="stable" version="1.29.0">
+      <manifest-digest sha256new="A7IUQJIPTRL6QNQ2WMYYYJ6DXJIOOVPOFBR7ISQTV3VZIDQF36EQ"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.29.0/atom-mac.zip" size="146559757" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=275b3c4dee4ec79790e2cf5fc8d95ac5df7431b4" main="Atom.exe" released="2018-08-28" stability="stable" version="1.30.0">
+      <manifest-digest sha256new="3O2IDOUGZD26ALHB7BFGDDPTIPB65RDD2D2TMP3MEBQUJZLOXP4A"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.30.0/atom-x64-windows.zip" size="145957876" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=ff6335f287e71d934230d5b1c73369f0134899b4" main="Atom.exe" released="2018-08-28" stability="stable" version="1.30.0">
+      <manifest-digest sha256new="5QVRED2HLFN7JT3VCEX2ZJAWQM6QEBBEEXAC62YFK2A3U6QRLTEQ"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.30.0/atom-windows.zip" size="135205006" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=79bf8f1b85929ea4ddd0e393d1568c5df76d6672" main="atom" released="2018-08-28" stability="stable" version="1.30.0">
+      <manifest-digest sha256new="UTKYJ5BD24ZRTLFMW4T2M6I52Y2KIVD3ET2SY5IIVQILJFNIGKOA"/>
+      <archive extract="atom-1.30.0-amd64" href="https://github.com/atom/atom/releases/download/v1.30.0/atom-amd64.tar.gz" size="141056153" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=c68d427ebe0d1f68cca63e828b64ad7eff22abba" main="Contents/MacOS/Atom" released="2018-08-28" stability="stable" version="1.30.0">
+      <manifest-digest sha256new="2FE33KJK54KQ6WUG7CN6GKBHRNWWCICXQ656BCBOB4R7NGUP4BYA"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.30.0/atom-mac.zip" size="145373004" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <entry-point binary-name="atom" command="run"/>
+
+  <capabilities os="Windows" xmlns="http://0install.de/schema/desktop-integration/capabilities">
+    <url-protocol id="atom">
+      <description>Atom URL</description>
+      <verb args="--uri-handler -- &quot;%1&quot;" command="atom" name="open"/>
+    </url-protocol>
+    <context-menu id="files-Atom">
+      <verb args="&quot;%1&quot;" command="atom" name="Atom">
+        <description>Open with Atom</description>
+      </verb>
+    </context-menu>
+    <context-menu id="directories-Atom" target="directories">
+      <verb args="&quot;%1&quot;" command="atom" name="Atom">
+        <description>Open with Atom</description>
+      </verb>
+    </context-menu>
+  </capabilities>
+</interface>

--- a/editors/atom.xml.template
+++ b/editors/atom.xml.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Atom</name>
+  <summary>the hackable text editor</summary>
+  <description>Atom is a hackable text editor for the 21st century, built on Electron, and based on everything we love about our favorite editors. We designed it to be deeply customizable, but still approachable using the default configuration.</description>
+  <homepage>https://atom.io/</homepage>
+  <icon href="http://0install.de/feed-icons/Atom.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="http://0install.de/feed-icons/Atom.png" type="image/png"/>
+  <category>Development</category>
+  <category>Utility</category>
+
+  <feed-for interface="http://repo.roscidus.com/editors/atom"/>
+
+  <group license="MIT License">
+    <implementation arch="Windows-x86_64" main="Atom.exe" released="{released}" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v{version}/atom-x64-windows.zip" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" main="Atom.exe" released="{released}" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v{version}/atom-windows.zip" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" main="atom" released="{released}" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="atom-{version}-amd64" href="https://github.com/atom/atom/releases/download/v{version}/atom-amd64.tar.gz" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" main="Contents/MacOS/Atom" released="{released}" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v{version}/atom-mac.zip" type="application/zip"/>
+    </implementation>
+  </group>
+</interface>

--- a/editors/vs-code.watch.py
+++ b/editors/vs-code.watch.py
@@ -1,0 +1,16 @@
+from urllib import request
+import json
+import re
+
+def handle(version):
+    linux64url = request.urlopen('https://vscode-update.azurewebsites.net/' + version + '/linux-x64/stable').url
+    linux32url = request.urlopen('https://vscode-update.azurewebsites.net/' + version + '/linux-ia32/stable').url
+    return {
+        'version': version,
+        'release-id': re.search('stable/([0-9a-f]{40})/code', linux64url).group(1),
+        'linux-amd64-timestamp': re.search('-([0-9]{10})', linux64url).group(1),
+        'linux-i386-timestamp': re.search('-([0-9]{10})', linux32url).group(1)
+    }
+
+data = request.urlopen('https://api.github.com/repos/Microsoft/vscode/tags').read().decode('utf-8')
+releases = [handle(tag['name'].strip('v')) for tag in json.loads(data) if not '/' in tag['name'] and not 'GOOD' in tag['name'] and not 'BAD' in tag['name'] and not 'bad' in tag['name']]

--- a/editors/vs-code.xml
+++ b/editors/vs-code.xml
@@ -1,0 +1,1258 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/editors/vs-code" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Visual Studio Code</name>
+  <summary>lightweight but powerful source code editor</summary>
+  <description>Visual Studio Code is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, macOS and Linux. It comes with built-in support for JavaScript, TypeScript and Node.js and has a rich ecosystem of extensions for other languages (such as C++, C#, Python, PHP, Go) and runtimes (such as .NET and Unity).</description>
+  <homepage>https://code.visualstudio.com/</homepage>
+  <icon href="http://0install.de/feed-icons/VS_Code.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="http://0install.de/feed-icons/VS_Code.png" type="image/png"/>
+  <category>Development</category>
+  <category>Utility</category>
+
+  <group license="MIT License">
+    <implementation arch="Windows-x86_64" id="sha1new=3b0666d1db9ba8191c1a57a2942f73e86e3fa20a" main="Code.exe" stability="stable" version="1.14.1">
+      <manifest-digest sha256new="FPJUKN63BOAYMMBELLVJUJ4XY4LXVRAJTM5WKRIYAUCUDCZTRA4Q"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/2648980a697a4c8fb5777dcfb2ab110cec8a2f58/VSCode-win32-x64-1.14.1.zip" size="66898924" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=8dd98f02365d1ea79d82be25ca2e0aa03762a6fd" main="Code.exe" stability="stable" version="1.14.1">
+      <manifest-digest sha256new="TBPKSX5R7TWFBUAR4NSKTJXDJUXJ33D244ASMXBXH6CIQXVFSAHA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/2648980a697a4c8fb5777dcfb2ab110cec8a2f58/VSCode-win32-ia32-1.14.1.zip" size="58016855" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=91c7d73803bd1c935900ef757e187e1ee9efb5f8" main="bin/code" stability="stable" version="1.14.1">
+      <manifest-digest sha256new="YBOQAES2T2O3OBCCOXTX7D4GILCVP3ELCIXAGIMF3MO27XA3XNFA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/2648980a697a4c8fb5777dcfb2ab110cec8a2f58/code-stable-code_1.14.1-1499973263_amd64.tar.gz" size="61500262" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=fcd8cf9921ee3827b62a5d0e2226ed57dbbbdb57" main="bin/code" stability="stable" version="1.14.1">
+      <manifest-digest sha256new="7LK5UQ7OTNCU5KQG3ETA7V2D6HL7JUSTYUPADFA6V35HLDUV7CTQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/2648980a697a4c8fb5777dcfb2ab110cec8a2f58/code-stable-code_1.14.1-1499973247_i386.tar.gz" size="62773477" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6adbefa63b95a68437d4578b4199184a68e4e77e" main="Code.exe" stability="stable" version="1.14.2">
+      <manifest-digest sha256new="D76SWPHZABEA3FZLIZDK3PUBC4BN532C3PVH44DXGLDKKLR5GI7Q"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/cb82febafda0c8c199b9201ad274e25d9a76874e/VSCode-win32-x64-1.14.2.zip" size="66897793" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=fe6571014d0cf1c7df41512ca50215955bc207de" main="Code.exe" stability="stable" version="1.14.2">
+      <manifest-digest sha256new="EDVBKWO64O4SWWJVTMVK3IZ4ALBLMZIG7YTGX5V7XFVPDKITJJOA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/cb82febafda0c8c199b9201ad274e25d9a76874e/VSCode-win32-ia32-1.14.2.zip" size="58015987" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=c9a58f12d83883e7870e726cda4970a760e2caa6" main="bin/code" stability="stable" version="1.14.2">
+      <manifest-digest sha256new="WNQY5CPSLLKWRLZIM4HNECLMYAU6HXWFF2HF5QMAAX222NZBMKAA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/cb82febafda0c8c199b9201ad274e25d9a76874e/code-stable-code_1.14.2-1500506907_amd64.tar.gz" size="61502692" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=8cfb01f245a02f05569be36e7a099a75dd6552bd" main="bin/code" stability="stable" version="1.14.2">
+      <manifest-digest sha256new="NJ2SW2QJGQG6R6Q2DVA26NXGDD4K43PFCNHDN3M2MWSECQMQEWNA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/cb82febafda0c8c199b9201ad274e25d9a76874e/code-stable-code_1.14.2-1500506872_i386.tar.gz" size="62775600" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=adf46d16c4e748d39f999c7733b816e92efe1bf1" main="Code.exe" stability="stable" version="1.15.0">
+      <manifest-digest sha256new="VMJX4IETQ2GBEQLOD7UPYRZ4C2ENHXOZSRUGMV7KXOGWWB2WSIGA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/8b95971d8cccd3afd86b35d4a0e098c189294ff2/VSCode-win32-x64-1.15.0.zip" size="67635399" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=6f74fa32f665654150407255ad9bc3ccef15fe87" main="Code.exe" stability="stable" version="1.15.0">
+      <manifest-digest sha256new="DHW6KZOT7EM3MZZGS7WWZOSNHIBJUF765U36OH7DZKWKVR5742ZQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/8b95971d8cccd3afd86b35d4a0e098c189294ff2/VSCode-win32-ia32-1.15.0.zip" size="58765801" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=6e84b88dd5e4883886d9ad44095a034d73077ab8" main="bin/code" stability="stable" version="1.15.0">
+      <manifest-digest sha256new="6XPWD3HAVA6JVH7H2323XSS6BX64UXIMNQWYJU7YBZYDG5M4UXYQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/8b95971d8cccd3afd86b35d4a0e098c189294ff2/code-stable-code_1.15.0-1502309460_amd64.tar.gz" size="61220337" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=b595a813ca5347993a969cf6dd15e231aceb7ed3" main="bin/code" stability="stable" version="1.15.0">
+      <manifest-digest sha256new="NK45FEWCQLTZI6A5WDPCX36ENA4BIYZ3HSWFQX5LXYBCGVHWNMAQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/8b95971d8cccd3afd86b35d4a0e098c189294ff2/code-stable-code_1.15.0-1502309315_i386.tar.gz" size="62485504" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=287fa6f55ce6f407228eaf58ebc166b334da9b74" main="Code.exe" stability="stable" version="1.15.1">
+      <manifest-digest sha256new="EY4FXQ443W3ZSPVTKKVZMU5XBQCLPUPNW2O3OB3XVDTMWL7K4JMA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/41abd21afdf7424c89319ee7cb0445cc6f376959/VSCode-win32-x64-1.15.1.zip" size="67633234" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=9b94b1b5ef97ce51cacc67ca8a8fed6a236f5594" main="Code.exe" stability="stable" version="1.15.1">
+      <manifest-digest sha256new="4GIM2E26G6ZRMUYM5PFCS3CKFV6NVOKEQR4OXQOZC2XEEI5X5FIQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/41abd21afdf7424c89319ee7cb0445cc6f376959/VSCode-win32-ia32-1.15.1.zip" size="58760319" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=066bcc912a6f6d91db5d41b292624bf255ccd900" main="bin/code" stability="stable" version="1.15.1">
+      <manifest-digest sha256new="4MARYGBT5CVKSOCX5BBKXLPN5OCECNLCL5H6CYS3GKGG7BTRBKPA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/41abd21afdf7424c89319ee7cb0445cc6f376959/code-stable-code_1.15.1-1502903936_amd64.tar.gz" size="61223800" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=f71aa8e7f3f0b1df5ce54a5823a42d81e75fcfaa" main="bin/code" stability="stable" version="1.15.1">
+      <manifest-digest sha256new="OLAQUHKXD5OATUQHWMQGE3B45APJZLNAWVLFDPNVMOUJ4G4DC4WA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/41abd21afdf7424c89319ee7cb0445cc6f376959/code-stable-code_1.15.1-1502903950_i386.tar.gz" size="62483946" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=c90f4dbce2dd5a32c38ae4b86382396e2ab54523" main="Code.exe" stability="stable" version="1.16.0">
+      <manifest-digest sha256new="4CGARJM74P7E7ZXOJ4BCKFCSR2OBSYDFJIRTB4U7SRHZB6Q5Z2HA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/787b31c0474e6165390b5a5989c9619e3e16f953/VSCode-win32-x64-1.16.0.zip" size="73113046" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=7214803f843d6b5d150cc799b144e71a825b428a" main="Code.exe" stability="stable" version="1.16.0">
+      <manifest-digest sha256new="ERWNDYJITAADP3OBEBEMR66LZZYVOLO6CG7CYVZQRS4RVMACVZLQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/787b31c0474e6165390b5a5989c9619e3e16f953/VSCode-win32-ia32-1.16.0.zip" size="63872165" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=8ec6d450de3e0e49a675e9bd5fed556984a999dc" main="bin/code" stability="stable" version="1.16.0">
+      <manifest-digest sha256new="27I2PBU3WD3FZ6TW2R2AZP7OEP2DSZJKEBBOGITUNMN3SSPBND7A"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/787b31c0474e6165390b5a5989c9619e3e16f953/code-stable-code_1.16.0-1504714880_amd64.tar.gz" size="64165296" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=2bafaa409a01e3bafb4ce96db8e4bd80ed373b6b" main="bin/code" stability="stable" version="1.16.0">
+      <manifest-digest sha256new="RDTOS5L5WEOID6H6DXH4MBFLB5BGTEDG3CS2BXZZX4CCVPNDBXAQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/787b31c0474e6165390b5a5989c9619e3e16f953/code-stable-code_1.16.0-1504714824_i386.tar.gz" size="65164821" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=0a7733e1528f584b7b49e944d88e85ad82e3367d" main="Code.exe" stability="stable" version="1.16.1">
+      <manifest-digest sha256new="M5FH3VI2E4TNOJGHPRBQYHTETQNCGOMRQUTMDSYGXCF4XV62XSZQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/27492b6bf3acb0775d82d2f87b25a93490673c6d/VSCode-win32-x64-1.16.1.zip" size="73110922" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=967144b5d74e7df1fa39fc1316fd073a1576a13d" main="Code.exe" stability="stable" version="1.16.1">
+      <manifest-digest sha256new="C74TB2GQQWX62BGGZKM2QQIJZZOHTCSHOUTCJIGTWAXKDVT5RWAQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/27492b6bf3acb0775d82d2f87b25a93490673c6d/VSCode-win32-ia32-1.16.1.zip" size="63872558" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=31d6e051f3e84c7678e6fd0bfaa3e19fd933dfe1" main="bin/code" stability="stable" version="1.16.1">
+      <manifest-digest sha256new="KFNZP5JZYCRSAGNPH5M5XJYQVWVIUK63LDZNNAQOXTX2VRSEW6OQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/27492b6bf3acb0775d82d2f87b25a93490673c6d/code-stable-code_1.16.1-1505406497_amd64.tar.gz" size="64162662" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=a6d3dd5cc1b127db014421124b54e9f8495b39b8" main="bin/code" stability="stable" version="1.16.1">
+      <manifest-digest sha256new="O3XX5NSP26YYH5EPQT2OFIQOT4CKMW74QRMPB6KUAJAAD742O6LA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/27492b6bf3acb0775d82d2f87b25a93490673c6d/code-stable-code_1.16.1-1505406503_i386.tar.gz" size="65164664" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=579c3ba7240fbd0eaa8383ceda72c7142362f934" main="Code.exe" stability="stable" version="1.17.0">
+      <manifest-digest sha256new="6FUNSO25USBTCPTLQ4PQUHN5GHDLWMWBYJEY77J2VBSHI6LD5IAQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/be377c0faf7574a59f84940f593a6849f12e4de7/VSCode-win32-x64-1.17.0.zip" size="67871557" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=56091235b45d3a93b056c6283583e20103ad9a12" main="Code.exe" stability="stable" version="1.17.0">
+      <manifest-digest sha256new="LVDDMREVA67HPJTP77DX2TCYRN2R2VE2IZ6LSKQH4PW663N4JUVQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/be377c0faf7574a59f84940f593a6849f12e4de7/VSCode-win32-ia32-1.17.0.zip" size="58815105" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=3c882a242b6992686ae99c2734ef14e4b5b2bf21" main="bin/code" stability="stable" version="1.17.0">
+      <manifest-digest sha256new="CDSE5IFTHEV5OBK6KGMMRP6P42NQNJUHJVTWKNVBCG5YBZ2YQXZA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/be377c0faf7574a59f84940f593a6849f12e4de7/code-stable-code_1.17.0-1507160143_amd64.tar.gz" size="63563553" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=280bb94898bbf1bde0bbc3010db2c99c5afd0200" main="bin/code" stability="stable" version="1.17.0">
+      <manifest-digest sha256new="NYNLYQFPBTGBLR24WFCZ6XPR5LLJDKX7BE4XO6HMPSXHVIPNCDFA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/be377c0faf7574a59f84940f593a6849f12e4de7/code-stable-code_1.17.0-1507160151_i386.tar.gz" size="64575849" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=8f9ae426d5bada2b4da651992e6f99b545a36c1c" main="Code.exe" stability="stable" version="1.17.1">
+      <manifest-digest sha256new="7OYSCRMVA2EEDUEXGVESILZADBOCJU7GNZBJ3GBE7WYJCM3R7YVQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/1e9d36539b0ae51ac09b9d4673ebea4e447e5353/VSCode-win32-x64-1.17.1.zip" size="67873076" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=6f5005a3b9a92e25612fd4498991b987232c049e" main="Code.exe" stability="stable" version="1.17.1">
+      <manifest-digest sha256new="BFYD4JQMY6H6BVIMVSTJSFKTK4JJZTLAUX4JSMAZJ65FP6GDTFDA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/1e9d36539b0ae51ac09b9d4673ebea4e447e5353/VSCode-win32-ia32-1.17.1.zip" size="58816545" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=fc7309e5faac8dae8c851bbf1b10a696ed30cc67" main="bin/code" stability="stable" version="1.17.1">
+      <manifest-digest sha256new="RJ66FQDZODXIILCXSW77HNAY2AXYL7W2RCXUFXYKHBYXJSFMQ3TA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/1e9d36539b0ae51ac09b9d4673ebea4e447e5353/code-stable-code_1.17.1-1507645403_amd64.tar.gz" size="63561705" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=b5e5337d6626ee6759208bab039a8d4e10c4c3a0" main="bin/code" stability="stable" version="1.17.1">
+      <manifest-digest sha256new="CKE6GQKLJOQGV3QJXIWVNYMEQ7N4UP5GUYVXBU2U5FPKL2N5KS5Q"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/1e9d36539b0ae51ac09b9d4673ebea4e447e5353/code-stable-code_1.17.1-1507645406_i386.tar.gz" size="64572634" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=0c6d86904a461716bfd4cab2864f01b16c1f3015" main="Code.exe" stability="stable" version="1.17.2">
+      <manifest-digest sha256new="JRXXFUYTJYMOO6E7EWQSKLI3PRPMJIP7TEFUT7RIXPWDQZ5C6D4Q"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/b813d12980308015bcd2b3a2f6efa5c810c33ba5/VSCode-win32-x64-1.17.2.zip" size="67994435" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=89283fdc3aaac2f1ead9d7d8974b4382f8152639" main="Code.exe" stability="stable" version="1.17.2">
+      <manifest-digest sha256new="ZMYFKPIO7IEDFPHKYSMUTPDVCZVVSTLOOSX7R63QPEMFI7XUM5SA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/b813d12980308015bcd2b3a2f6efa5c810c33ba5/VSCode-win32-ia32-1.17.2.zip" size="58937081" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=d504786a57748293b146ac8471ceef7dc6b952e8" main="bin/code" stability="stable" version="1.17.2">
+      <manifest-digest sha256new="GTZLKVFZMG4M4VSBXKNSVKRKL5KWAEHSUIXQ4BXZILHSNVFZBFIA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/b813d12980308015bcd2b3a2f6efa5c810c33ba5/code-stable-code_1.17.2-1508162334_amd64.tar.gz" size="63563710" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=8ac57252d04a25320bd9d0302b4a7d808ab6ab34" main="bin/code" stability="stable" version="1.17.2">
+      <manifest-digest sha256new="LSC5SZNS6SSHPLMAT5NSU6FNIS7JWBRNS7WJHMPZESZTOHUPE42A"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/b813d12980308015bcd2b3a2f6efa5c810c33ba5/code-stable-code_1.17.2-1508162326_i386.tar.gz" size="64561714" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=314e59e391d3d581755a11d3a6e82155c4c04dd9" main="Code.exe" released="2017-11-15" stability="stable" version="1.18.0">
+      <manifest-digest sha256new="TJPLKCEJ7HNPVXL2UOVSBYUC3FSL7IFDNUONYGJY42YPL6YNJTIA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/dcee2202709a4f223185514b9275aa4229841aa7/VSCode-win32-x64-1.18.0.zip" size="72320924" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=182a71b0d0710f6af906ecf8259ac2f0129bf4bd" main="Code.exe" released="2017-11-15" stability="stable" version="1.18.0">
+      <manifest-digest sha256new="WMV3T3SHD2YQDI5ZNP3RDMXYYQ34OM6WR2NB723BJ5ECGRCYUCQQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/dcee2202709a4f223185514b9275aa4229841aa7/VSCode-win32-ia32-1.18.0.zip" size="63278595" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=ccb23dd240c998ac3c6b40cc380cb0d7195a88f4" main="bin/code" released="2017-11-15" stability="stable" version="1.18.0">
+      <manifest-digest sha256new="MCBMLNJKWAGDV7GFV5UWAEUPMEQBS2SN3WA77Z7CFBOJJE7DPYLA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/dcee2202709a4f223185514b9275aa4229841aa7/code-stable-code_1.18.0-1510145176_amd64.tar.gz" size="64841244" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=8cc2aeb1d330394ab81195c8d59c2031ee6a8b6a" main="bin/code" released="2017-11-15" stability="stable" version="1.18.0">
+      <manifest-digest sha256new="UEU2HH3P3TQZU7L6KOV6FVOJUY7IEPZJCZZC6SPCWFEVY2AR5EJA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/dcee2202709a4f223185514b9275aa4229841aa7/code-stable-code_1.18.0-1510145103_i386.tar.gz" size="65857286" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=a0bb16136605a3e790fd2370032e6fb992f9be68" main="Code.exe" released="2017-12-07" stability="stable" version="1.18.1">
+      <manifest-digest sha256new="UFP2GV25LSXODJW73YTD7BJRHH2XDNYPHSJWCEF3CIEUPM5VQ2WQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/929bacba01ef658b873545e26034d1a8067445e9/VSCode-win32-x64-1.18.1.zip" size="72322591" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=8830bf063c78924b9d0575bfdf8e3fed5b545c08" main="Code.exe" released="2017-12-07" stability="stable" version="1.18.1">
+      <manifest-digest sha256new="6HYULU4DXFDGUTHUGJSOMVFGZODAGRPEOWBCSG644H5PQHAAY4HA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/929bacba01ef658b873545e26034d1a8067445e9/VSCode-win32-ia32-1.18.1.zip" size="63220463" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=b3b8845d4bcc5541c93e029aab06b7f3c214af08" main="bin/code" released="2017-12-07" stability="stable" version="1.18.1">
+      <manifest-digest sha256new="NNAJE3Y3HAEJZQRUIBPRJSZVAIN6YJX4BU6X74PDENLWZIMXXJMQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/929bacba01ef658b873545e26034d1a8067445e9/code-stable-code_1.18.1-1510857349_amd64.tar.gz" size="64846354" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=7621ef06dd727011a15dd8a43d77cf99635b8975" main="bin/code" released="2017-12-07" stability="stable" version="1.18.1">
+      <manifest-digest sha256new="EKSF6CVRSNEQQKJIXG55TJ5E2AE7UGGDEPV4UI7XKWMILKLA544A"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/929bacba01ef658b873545e26034d1a8067445e9/code-stable-code_1.18.1-1510857313_i386.tar.gz" size="65859677" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6360bb69bb9a312b0c401a8e5d483c4980cb9575" main="Code.exe" released="2017-12-21" stability="stable" version="1.19.0">
+      <manifest-digest sha256new="CJI7RMFIIA2RVT3MVEVLBPO23GMYJEJA5P2FCL5AKEX65DZCM4BQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/816be6780ca8bd0ab80314e11478c48c70d09383/VSCode-win32-x64-1.19.0.zip" size="74437662" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=11149b6ca6444edb826cfd4c746579a71b4ce0e2" main="Code.exe" released="2017-12-21" stability="stable" version="1.19.0">
+      <manifest-digest sha256new="R6SOSJCTD5XJFFX4NVGLS5RFS7RMJGVBMQBGGZMC4QWYIPMPDMRA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/816be6780ca8bd0ab80314e11478c48c70d09383/VSCode-win32-ia32-1.19.0.zip" size="65311103" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=a62e2a0af8cd5c97543016b1213e2eade6f2597b" main="bin/code" released="2017-12-21" stability="stable" version="1.19.0">
+      <manifest-digest sha256new="JAAY2TSZKR43T3TFHL5W6BVB76WLYAQMOAAPGKTJQ523XBYIFCVA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/816be6780ca8bd0ab80314e11478c48c70d09383/code-stable-code_1.19.0-1513245498_amd64.tar.gz" size="66894496" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=d753d02c8bd5bcd6c51f95081abc39027761a41e" main="bin/code" released="2017-12-21" stability="stable" version="1.19.0">
+      <manifest-digest sha256new="VWXISI4JUO3E6JEXM363MBGDMERNRKHVQLYH7F5BARNQ3UUBJJ2Q"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/816be6780ca8bd0ab80314e11478c48c70d09383/code-stable-code_1.19.0-1513245559_i386.tar.gz" size="67914654" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6477e1f2bb38e2860164f0e20bc0d577fa1ad3aa" main="Code.exe" released="2018-01-12" stability="stable" version="1.19.1">
+      <manifest-digest sha256new="BP5CA4YN2Q36G2FPHPTMTE5UOI4HX5IKBQLZOUO4NIZFNQMMF5QQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/0759f77bb8d86658bc935a10a64f6182c5a1eeba/VSCode-win32-x64-1.19.1.zip" size="74456191" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=02ab3a6e4971dba69e5955c9c2a5fda90dd2e248" main="Code.exe" released="2018-01-12" stability="stable" version="1.19.1">
+      <manifest-digest sha256new="CHF7MASCDT4S57QDK364H5IA5LJD23U5KGE34Z5YVFSRS5RTMSEA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/0759f77bb8d86658bc935a10a64f6182c5a1eeba/VSCode-win32-ia32-1.19.1.zip" size="65326132" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=c2896d54944ba00b3dc00724208fd51ba55ce452" main="bin/code" released="2018-01-12" stability="stable" version="1.19.1">
+      <manifest-digest sha256new="DYNV6I7F5ZQAS3GEBDTTQOLWZFO4UCQDKZ2IHYTAIAN4E36WGXNQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/0759f77bb8d86658bc935a10a64f6182c5a1eeba/code-stable-code_1.19.1-1513676564_amd64.tar.gz" size="66905942" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=6e7e1c1474f88b16d3084f8768f19d54a791ecd0" main="bin/code" released="2018-01-12" stability="stable" version="1.19.1">
+      <manifest-digest sha256new="VEPNQPXENJTVGFL4SNYMM5EWVYMDVTITZJPYRRKKVWWWEMNNZPXQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/0759f77bb8d86658bc935a10a64f6182c5a1eeba/code-stable-code_1.19.1-1513676574_i386.tar.gz" size="67918083" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=dd82476532301ee85f23741076c28981ed665306" main="Code.exe" released="2018-01-12" stability="stable" version="1.19.2">
+      <manifest-digest sha256new="ITV4HISIWYWN2C537O54MXYUDN5VM2P4MUCSRC3GWE37IFVYVZ7Q"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/490ef761b76b3f3b3832eff7a588aac891e5fe80/VSCode-win32-x64-1.19.2.zip" size="74458030" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=4a306cfbeac0afac47792d1b6cc6486ab3c71936" main="Code.exe" released="2018-01-12" stability="stable" version="1.19.2">
+      <manifest-digest sha256new="TLYXIUMMXQFYGWK3FX52XL3ZKF2P7P2UWBC6FD3U6VQ2IV2NCNKQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/490ef761b76b3f3b3832eff7a588aac891e5fe80/VSCode-win32-ia32-1.19.2.zip" size="65329062" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=3a6e84a7a20c85460e20f02170188fddfd7b067b" main="bin/code" released="2018-01-12" stability="stable" version="1.19.2">
+      <manifest-digest sha256new="EBY6H7IJNOGVPZ7W2EFZ6PKHR2GZGXTCEBINPGMNKGNYZTJ32TIA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/490ef761b76b3f3b3832eff7a588aac891e5fe80/code-stable-code_1.19.2-1515599945_amd64.tar.gz" size="66905949" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=06fffcfc403e7b2e1fe43747726a0912d84fe714" main="bin/code" released="2018-01-12" stability="stable" version="1.19.2">
+      <manifest-digest sha256new="MWP6Z7L6AYILJS7IXPMANVW3WRJIOMUM5RUY2W24OA2TVGFZNIFA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/490ef761b76b3f3b3832eff7a588aac891e5fe80/code-stable-code_1.19.2-1515599957_i386.tar.gz" size="67919755" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=11d44b1273bae5c7991c052df13fa1ecc86f0856" main="Code.exe" released="2018-02-14" stability="stable" version="1.19.3">
+      <manifest-digest sha256new="2IXZQPFUHKUJRSTCFHB3VDIYQRBNC3DIPE6QT57NSVHWGDV3GI3A"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/7c4205b5c6e52a53b81c69d2b2dc8a627abaa0ba/VSCode-win32-x64-1.19.3.zip" size="74458685" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=b55c4b6fb79f40c7a447afb8c6d51b2a4d4ba5b1" main="Code.exe" released="2018-02-14" stability="stable" version="1.19.3">
+      <manifest-digest sha256new="RTCRPTXNDM66XFEXRONKVQYITHXAXP3O6QLOFVF3HYNNABA3F54Q"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/7c4205b5c6e52a53b81c69d2b2dc8a627abaa0ba/VSCode-win32-ia32-1.19.3.zip" size="65329120" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=973136fe520dc2e0c3fbd4da65a26482ff20040c" main="bin/code" released="2018-02-14" stability="stable" version="1.19.3">
+      <manifest-digest sha256new="J73WSCTNWAWC4H3BXVVD7TDXPQESBBISCQFECSUXIFJTYCESL2XQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/7c4205b5c6e52a53b81c69d2b2dc8a627abaa0ba/code-stable-code_1.19.3-1516876437_amd64.tar.gz" size="66903595" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=781fcdffe00bc6344552dcee48090a332d951863" main="bin/code" released="2018-02-14" stability="stable" version="1.19.3">
+      <manifest-digest sha256new="VYVBBKSY7H7RHHX3ZENGW2CQRMETL5KTTJUYU7VBEFL3EVSYCVJQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/7c4205b5c6e52a53b81c69d2b2dc8a627abaa0ba/code-stable-code_1.19.3-1516876497_i386.tar.gz" size="67921920" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=192e5f388113d8e5f1952cde279e7868722927b5" main="Code.exe" released="2018-02-14" stability="stable" version="1.20.0">
+      <manifest-digest sha256new="YEI2CUXVILYHHBEQFLA5RTAAQNU62ID2OISEGFOWMMJIA5HOA2UA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/c63189deaa8e620f650cc28792b8f5f3363f2c5b/VSCode-win32-x64-1.20.0.zip" size="72685640" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=48501d057f742c445fd7e973d20d55bbe47c6563" main="Code.exe" released="2018-02-14" stability="stable" version="1.20.0">
+      <manifest-digest sha256new="Z22IS4DZGGB7A2P2Q762CCAUY5CHJCGGFG54J6BEHGI7LTAT2T2A"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/c63189deaa8e620f650cc28792b8f5f3363f2c5b/VSCode-win32-ia32-1.20.0.zip" size="63397343" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=d5f945013d4be4b05c8fcb8fe25c95111be7b5b5" main="bin/code" released="2018-02-14" stability="stable" version="1.20.0">
+      <manifest-digest sha256new="CQ7VR6BHUMNSR7E643GJ4JFSEOGLOEF4FUFS7GY3AEVH5672LLBA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/c63189deaa8e620f650cc28792b8f5f3363f2c5b/code-stable-code_1.20.0-1518023506_amd64.tar.gz" size="67737146" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=de3ce91fbe85f99d7346181d2470f738418a2ba9" main="bin/code" released="2018-02-14" stability="stable" version="1.20.0">
+      <manifest-digest sha256new="AWSTJY5TSORY46NNEA5B6OG536DSET7426VTC6BD3EYJUJ6YVVEQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/c63189deaa8e620f650cc28792b8f5f3363f2c5b/code-stable-code_1.20.0-1518023590_i386.tar.gz" size="68758682" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=77d4ebffcfc9a9933e2eeac43c839998f9c6d31b" main="Code.exe" released="2018-02-14" stability="stable" version="1.20.1">
+      <manifest-digest sha256new="VXKFF3NJH7IVZQITHWUKARDRUAC4PBLXCNAVTDYO6AJOFXMZ2GMA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/f88bbf9137d24d36d968ea6b2911786bfe103002/VSCode-win32-x64-1.20.1.zip" size="70445837" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=2dfc53c2758c65f695e5b31948b64d064b174e7f" main="Code.exe" released="2018-02-14" stability="stable" version="1.20.1">
+      <manifest-digest sha256new="XM2FTW7PWQ3OM6VZ2HWZRRYZFAALNP3X4S2PF72F5HKT73TISMUA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/f88bbf9137d24d36d968ea6b2911786bfe103002/VSCode-win32-ia32-1.20.1.zip" size="61196674" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=88e060fed8f5a6ddb9199544180d03983440ad79" main="bin/code" released="2018-02-14" stability="stable" version="1.20.1">
+      <manifest-digest sha256new="TFP464IYDH7RTJ42RSLU2UYHYBZKMOJK4EOA6BX5VO4FBKO5JCXA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/f88bbf9137d24d36d968ea6b2911786bfe103002/code-stable-code_1.20.1-1518535978_amd64.tar.gz" size="65805135" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=2831cb14d02ce72fe8fee22d5abfb5c8c0f55164" main="bin/code" released="2018-02-14" stability="stable" version="1.20.1">
+      <manifest-digest sha256new="YZGVK6N2QMYCHASPNARXAJJFG6M5C5RH6VDTB4MAJ5AOGWM6O6KA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/f88bbf9137d24d36d968ea6b2911786bfe103002/code-stable-code_1.20.1-1518535974_i386.tar.gz" size="66820122" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=425194eeb37f9889e2692a491fb5cc205033cf27" main="Code.exe" released="2018-03-12" stability="stable" version="1.21.0">
+      <manifest-digest sha256new="IHXQ7KGQ5S4PLWW43GTTENTHGHLCMCIU6QZIGEDCE2PABRX3STJQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/9a199d77c82fcb82f39c68bb33c614af01c111ba/VSCode-win32-x64-1.21.0.zip" size="71733623" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=e50a58387dfb6aab58037e38aff49e44e0ebe2e3" main="Code.exe" released="2018-03-12" stability="stable" version="1.21.0">
+      <manifest-digest sha256new="W5WYRLPSMOKS26I66PGIRABFOFWXTBUTQ75HJMXQS2C6PAZGVKTA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/9a199d77c82fcb82f39c68bb33c614af01c111ba/VSCode-win32-ia32-1.21.0.zip" size="62483678" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=2b6629faf7b1be9534275d301aeab8e22403ab92" main="bin/code" released="2018-03-12" stability="stable" version="1.21.0">
+      <manifest-digest sha256new="WEY5F3GSPGKQUVDQTBUZQMTFIIFR5O3YBDBLYOQYMSYOB4Z5AO2A"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/9a199d77c82fcb82f39c68bb33c614af01c111ba/code-stable-code_1.21.0-1520420608_amd64.tar.gz" size="67060331" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=edbacbd5d6acb7a96fab5ffdc29cfc36deba90a2" main="bin/code" released="2018-03-12" stability="stable" version="1.21.0">
+      <manifest-digest sha256new="JGMAACNVWAOCWC6LU7DU4HQKNGHJND7IHVDLG75ITNTGKPR5FRNQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/9a199d77c82fcb82f39c68bb33c614af01c111ba/code-stable-code_1.21.0-1520420595_i386.tar.gz" size="68081572" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=35370d553f68f17e99a0ce5e6b01c2250f133247" main="Code.exe" released="2018-03-21" stability="stable" version="1.21.1">
+      <manifest-digest sha256new="LJBR7FDUZYZMJUHT5D2YVKPQPLTQSNKHJELWL7ONJPINISZYM7OA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/79b44aa704ce542d8ca4a3cc44cfca566e7720f1/VSCode-win32-x64-1.21.1.zip" size="71731785" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=571355cd9f0d89f8fb080ad662d4811cecd78369" main="Code.exe" released="2018-03-21" stability="stable" version="1.21.1">
+      <manifest-digest sha256new="UCL656FGWGLRGQVRPOHXRWB6J7PIA62QU5VI4HXV5B2HDEA4LVLA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/79b44aa704ce542d8ca4a3cc44cfca566e7720f1/VSCode-win32-ia32-1.21.1.zip" size="62486391" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=f59b77414a72b76f0b206657ad1b244f446e2c6a" main="bin/code" released="2018-03-21" stability="stable" version="1.21.1">
+      <manifest-digest sha256new="NEFA225L2B374HG4MK2DJOTRXKVEX4ELX3DSGOO54DZW7ITWCLLQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/79b44aa704ce542d8ca4a3cc44cfca566e7720f1/code-stable-code_1.21.1-1521038896_amd64.tar.gz" size="67065892" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=762d87ed2855c96522745a0c650003a015e4544e" main="bin/code" released="2018-03-21" stability="stable" version="1.21.1">
+      <manifest-digest sha256new="LTCQ2KN7ECUCUHGXXHFY6XYVSXXKWTQSLZDQQYDYJXPITAG5YZ6A"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/79b44aa704ce542d8ca4a3cc44cfca566e7720f1/code-stable-code_1.21.1-1521038898_i386.tar.gz" size="68083785" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=eca22289c55d597be4531ac97ad0c64290aebe3f" main="Code.exe" released="2018-04-11" stability="stable" version="1.22.1">
+      <manifest-digest sha256new="SKHNGLA23RCKL5IGHIC3E77OSRPH5BHONWSEM4QXBO756KGLHFBA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/950b8b0d37a9b7061b6f0d291837ccc4015f5ecd/VSCode-win32-x64-1.22.1.zip" size="73213770" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=adf97920d769e53cf7257867c1179cee22d76a87" main="Code.exe" released="2018-04-11" stability="stable" version="1.22.1">
+      <manifest-digest sha256new="75YPGGHEYXG7PHPBGHVFR52B4DHFHKPX7R7WVTZNBGM6J466PABQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/950b8b0d37a9b7061b6f0d291837ccc4015f5ecd/VSCode-win32-ia32-1.22.1.zip" size="63960188" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=c197d7a0fdfd483e43493a78545a4afe4fb7d495" main="bin/code" released="2018-04-11" stability="stable" version="1.22.1">
+      <manifest-digest sha256new="7HFYHCQQGFLG3VS6Z7KZRA5L3SFCTCQGDCKEJFIONXTJNSRXOSUA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/950b8b0d37a9b7061b6f0d291837ccc4015f5ecd/code-stable-code_1.22.1-1522974421_amd64.tar.gz" size="68391282" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=b0e84ab400e110543aa82caf7272a580e5af630d" main="bin/code" released="2018-04-11" stability="stable" version="1.22.1">
+      <manifest-digest sha256new="XNOET5CMWFM2TYTZDOVQXM5T5N62DW2TLZOWWKRTSPV45U6CYABQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/950b8b0d37a9b7061b6f0d291837ccc4015f5ecd/code-stable-code_1.22.1-1522974427_i386.tar.gz" size="69286998" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=aae34a290878410fd8b970f84a1ee7f974d7a660" main="Code.exe" released="2018-04-11" stability="stable" version="1.22.0">
+      <manifest-digest sha256new="XEHINKYSR7NKN3ZNOUWZJX7F2S5JS5ILB2ZA5BHHBSNAH3NA5LEA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/6b4d53cdab8bcae1eaaa4934d93c077319b573db/VSCode-win32-x64-1.22.0.zip" size="73214583" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=5a4e0f2ee9590a0cd9bbe139e1ae00eaf222f9f0" main="Code.exe" released="2018-04-11" stability="stable" version="1.22.0">
+      <manifest-digest sha256new="PHZNYS2AOIZLQTSN7QHPINXHR7MYFGICYY73WTBRAW4XIXBGLF6A"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/6b4d53cdab8bcae1eaaa4934d93c077319b573db/VSCode-win32-ia32-1.22.0.zip" size="63959397" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=21638de40d11fbaaed067555d0419359b2262c35" main="bin/code" released="2018-04-11" stability="stable" version="1.22.0">
+      <manifest-digest sha256new="5PYECN7VBVEMKA5V4NKYRHYMQ6ROSCKXOY2Z6JQ6BEUUVXO3WGOQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/6b4d53cdab8bcae1eaaa4934d93c077319b573db/code-stable-code_1.22.0-1522949221_amd64.tar.gz" size="68397476" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=efc9ec3b957d998995c5be06dbb858fd7c42d97d" main="bin/code" released="2018-04-11" stability="stable" version="1.22.0">
+      <manifest-digest sha256new="L4NDSMQTW3AHPJG53P5OCG3FWFN4KKTEINYGZ7FUHBCNLTTO4JIQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/6b4d53cdab8bcae1eaaa4934d93c077319b573db/code-stable-code_1.22.0-1522949227_i386.tar.gz" size="69289374" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=b534dcae6d6523d29581918a2abc199f1904f5ea" main="Code.exe" released="2018-05-08" stability="stable" version="1.22.2">
+      <manifest-digest sha256new="WOTLVDXKOAVASNYGN7JHSUOSEITAVONZUSIBZP34X3SYPTDKR4BQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/3aeede733d9a3098f7b4bdc1f66b63b0f48c1ef9/VSCode-win32-x64-1.22.2.zip" size="73213702" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=91436ccc34aee933dfd263c767fbbc8f28684956" main="Code.exe" released="2018-05-08" stability="stable" version="1.22.2">
+      <manifest-digest sha256new="QPHPTOXJKNF6SEPZC5GSXVPL6M3C4TSALAIPGAG7H2R63TSKZ2IQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/3aeede733d9a3098f7b4bdc1f66b63b0f48c1ef9/VSCode-win32-ia32-1.22.2.zip" size="63959480" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=7a517ef5817d4d7242e66fa04e36df801f5a1a4f" main="bin/code" released="2018-05-08" stability="stable" version="1.22.2">
+      <manifest-digest sha256new="7SHU4OULPIDRQGRDQD4HFNKFZ3B3IWKC55IQ7TJ7P45VL2MAB54Q"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/3aeede733d9a3098f7b4bdc1f66b63b0f48c1ef9/code-stable-code_1.22.2-1523551015_amd64.tar.gz" size="68394134" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=e989652e6c9495be773b7c23e8324e66957da735" main="bin/code" released="2018-05-08" stability="stable" version="1.22.2">
+      <manifest-digest sha256new="HF54PPY56OU26AQXFC745HVKRYLNQM7NM6XYHN4QNYUNAH2EYRIQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/3aeede733d9a3098f7b4bdc1f66b63b0f48c1ef9/code-stable-code_1.22.2-1523551020_i386.tar.gz" size="69287252" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=05518d398c32a7c85f4500f6c56792df7bd467af" main="Code.exe" released="2018-05-08" stability="stable" version="1.23.0">
+      <manifest-digest sha256new="FZEFMNTMR6DTYNHBJPZSAT4VK4IYIUW3AVJXL4MI3ADLPPNM2VDA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/7c7da59c2333a1306c41e6e7b68d7f0caa7b3d45/VSCode-win32-x64-1.23.0.zip" size="73135608" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=a8fa49b0f0230933e70717e26e2f49fb2e6afbac" main="Code.exe" released="2018-05-08" stability="stable" version="1.23.0">
+      <manifest-digest sha256new="P7GVIGZS33RF4IJGXQSKQFRDDPSRBL6VWZKSLEAI3LD66SALXLDQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/7c7da59c2333a1306c41e6e7b68d7f0caa7b3d45/VSCode-win32-ia32-1.23.0.zip" size="63881595" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=de62d846c98dc3540c67b960c017f01bcd420fdf" main="bin/code" released="2018-05-08" stability="stable" version="1.23.0">
+      <manifest-digest sha256new="DC5OTZNLCJKVDBBRDCMWBZ3W7GFSOLFNJ7AHPDZYX55ZQ6QQQDPA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/7c7da59c2333a1306c41e6e7b68d7f0caa7b3d45/code-stable-code_1.23.0-1525361119_amd64.tar.gz" size="68323125" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=2b60e29745fdf4c0bb91dbcfb6b7f6ed6b40c005" main="bin/code" released="2018-05-08" stability="stable" version="1.23.0">
+      <manifest-digest sha256new="ACXPHFYG7GRNTCRX32SGP7FRX33ZV4KAOVC6PYKPZSIEC3BWJ4BA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/7c7da59c2333a1306c41e6e7b68d7f0caa7b3d45/code-stable-code_1.23.0-1525361219_i386.tar.gz" size="69222082" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=d0c9496242f9804341baa7ebed1feea7b75947ee" main="Code.exe" released="2018-06-13" stability="stable" version="1.23.1">
+      <manifest-digest sha256new="6CCF5MMKM55EWSO2XYB776HBP7IDBLZN2AW6LXEICHFPQXHPXGZQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/d0182c3417d225529c6d5ad24b7572815d0de9ac/VSCode-win32-x64-1.23.1.zip" size="73135891" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=21fc3587a63ba189b176e402fc9639caf8f806b7" main="Code.exe" released="2018-06-13" stability="stable" version="1.23.1">
+      <manifest-digest sha256new="RFKOA3HSXTLWEEAKCPU2AZDNCRDXVXBYMS7GFYDG7FT3CFEPL6TQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/d0182c3417d225529c6d5ad24b7572815d0de9ac/VSCode-win32-ia32-1.23.1.zip" size="63882279" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=e12bf3f59160fdd7fca462f2cb666559bea41535" main="bin/code" released="2018-06-13" stability="stable" version="1.23.1">
+      <manifest-digest sha256new="XOMFO3VCYMG56WHY7HHYTTXLPH6CK2NRJFOOS7V3ZDTCEKYQNI7Q"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/d0182c3417d225529c6d5ad24b7572815d0de9ac/code-stable-code_1.23.1-1525968403_amd64.tar.gz" size="68325851" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=32337e0777ca12078eb7e85e8e20d06b2fbdbada" main="bin/code" released="2018-06-13" stability="stable" version="1.23.1">
+      <manifest-digest sha256new="KA6A7YDWEYQUFKDG7YPBSGBCBWLY75FTJMLJLY34FD2FOLEXJ7HQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/d0182c3417d225529c6d5ad24b7572815d0de9ac/code-stable-code_1.23.1-1525968397_i386.tar.gz" size="69221155" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=1b1b20214b8d69b29ce3e244460635b0d34d2480" main="Code.exe" released="2018-06-13" stability="stable" version="1.24.0">
+      <manifest-digest sha256new="OOLWW52HQ6VVFDTNG4WPFGNXHEUV5POK76WJLVMY25DTVRPYXZGQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/6a6e02cef0f2122ee1469765b704faf5d0e0d859/VSCode-win32-x64-1.24.0.zip" size="75096738" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=73202db5e2ba075e2f632189d7926a92a3f9716d" main="Code.exe" released="2018-06-13" stability="stable" version="1.24.0">
+      <manifest-digest sha256new="SA3A66B3TQN6A74TPA3QHINIJY2R2R2B7QKTBKMJPKXDHVO4DYMA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/6a6e02cef0f2122ee1469765b704faf5d0e0d859/VSCode-win32-ia32-1.24.0.zip" size="65771549" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=d85ea2d120a3c9d91120b92fbd4aca2b097dc9c5" main="bin/code" released="2018-06-13" stability="stable" version="1.24.0">
+      <manifest-digest sha256new="GFKZSAQSL5LD4KFVDSRNFWKJVEZSUJGTGAUM5YOZMPVYBFUGIZ3A"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/6a6e02cef0f2122ee1469765b704faf5d0e0d859/code-stable-code_1.24.0-1528306776_amd64.tar.gz" size="70371127" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=4fc0e59cc3dcb7437e7d3d5f950854b02cc129a5" main="bin/code" released="2018-06-13" stability="stable" version="1.24.0">
+      <manifest-digest sha256new="UUXZ37LJMHCSLIW7E5W6CNQCADIAVP4L4V6QPG5GY5VFROUQDEJQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/6a6e02cef0f2122ee1469765b704faf5d0e0d859/code-stable-code_1.24.0-1528306775_i386.tar.gz" size="71307420" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=1b8232304cba88cdbaadf300cd73eebfb0ffcec1" main="Code.exe" released="2018-07-04" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="EARJADD3SDERH2OZYQEQQ2BL5HIUSBUR3TIJXKODN2VX6KHWXMKA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/24f62626b222e9a8313213fb64b10d741a326288/VSCode-win32-x64-1.24.1.zip" size="75165429" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=d7904a957cf6a269fe271a1e69f22d2c49694b6b" main="Code.exe" released="2018-07-04" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="DVV4V74QEAHFCJLAUVDHPEUBVPG7BT27ORMA4Z4SS7FC4RXESCDA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/24f62626b222e9a8313213fb64b10d741a326288/VSCode-win32-ia32-1.24.1.zip" size="65835528" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=5ccb9e0d1ee7b3c331aac641a50b1f18e7af4d52" main="bin/code" released="2018-07-04" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="MM6PUR6HK33476P5WZFIE5ROBV455CATJKAPISI47T3WOHDB6QVQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/24f62626b222e9a8313213fb64b10d741a326288/code-stable-code_1.24.1-1528912196_amd64.tar.gz" size="70368270" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=9622a1568d58cc93593b4513eb41a023dd68b682" main="bin/code" released="2018-07-04" stability="stable" version="1.24.1">
+      <manifest-digest sha256new="Y3IXR6BCIMCQGNJTQ75NGWL33WIE76ILCP42QA6KUIUT6PUC6J6A"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/24f62626b222e9a8313213fb64b10d741a326288/code-stable-code_1.24.1-1528912284_i386.tar.gz" size="71307539" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=c85c51ff6c2a4662aadf8bdebe5734268dd77f7b" main="Code.exe" released="2018-07-11" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="34GKABXBL5B2GM6XIETRJZBRVJHOBWHTUXXQ6HZZJKPCBNVYUPSQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/0f080e5267e829de46638128001aeb7ca2d6d50e/VSCode-win32-x64-1.25.0.zip" size="77387894" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=1ffe4691bd75cbdd2b1fe9663fc86a96b5f69932" main="Code.exe" released="2018-07-11" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="FCZTT5E23OSHTMAEJYSVJLPFUEB7CLEFKR44Y4V76EP2PQWCAHUA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/0f080e5267e829de46638128001aeb7ca2d6d50e/VSCode-win32-ia32-1.25.0.zip" size="68059258" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=f3736efe1b3dae99cefeeb9387620882d4f7a66e" main="bin/code" released="2018-07-11" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="JIFWJ7CJGIN53AEHMVMGZQSBPB2NABKUKTSWZ5RPU34IMWUD7H6A"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/0f080e5267e829de46638128001aeb7ca2d6d50e/code-stable-code_1.25.0-1530796411_amd64.tar.gz" size="71667614" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=ceaf69272b54a3bfcf20c8b3216d7b81a0ce5e5c" main="bin/code" released="2018-07-11" stability="stable" version="1.25.0">
+      <manifest-digest sha256new="B6G2B2ACKIER4BOAXBMPZLMRSXCTXXLMN3HOHOZBDXCQF4Z2F74A"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/0f080e5267e829de46638128001aeb7ca2d6d50e/code-stable-code_1.25.0-1530796387_i386.tar.gz" size="72610561" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=90e4ea04db621086d10540a0ca87a33b25437815" main="Code.exe" released="2018-07-19" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="4K35RPPPYGVTCNP4WIZG4RLZT7IPLMODPS6PXP3IQL42C6OPS35A"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/1dfc5e557209371715f655691b1235b6b26a06be/VSCode-win32-x64-1.25.1.zip" size="77388782" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=d9b674a7d5176e308e4afbfa6b49ca5fb1841690" main="Code.exe" released="2018-07-19" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="ZU5YAWXG5LLMSQLYLNAG7F6C7RFQV4J4LBSIAUFOCL663JKRSKWQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/1dfc5e557209371715f655691b1235b6b26a06be/VSCode-win32-ia32-1.25.1.zip" size="68058943" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=a1b6e3d8cc722a75e1764da8ceedecd76bcf4a6a" main="bin/code" released="2018-07-19" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="ASQCRP7NW2QBNX6N6Q22UQP3EJZQ6XR6VRA6CMIE5RG3AESREMMA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/1dfc5e557209371715f655691b1235b6b26a06be/code-stable-code_1.25.1-1531323788_amd64.tar.gz" size="71669633" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=0d375a9afd13285fd00a1136ca3d13b03e9c858c" main="bin/code" released="2018-07-19" stability="stable" version="1.25.1">
+      <manifest-digest sha256new="342LYYX6EYB5GBJ3XOKBQYV37PFNCMLGED7WHHQ26N2G6INY24UA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/1dfc5e557209371715f655691b1235b6b26a06be/code-stable-code_1.25.1-1531323780_i386.tar.gz" size="72608871" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6e222d82c148332f5ec69da3b0f50ea363331e1c" main="Code.exe" released="2018-08-15" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="66QOGCOQDUWJTAINK2GMCEI5IEJCHJHJ5YPV7ORWLJJ52EBXOM5A"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/4e9361845dc28659923a300945f84731393e210d/VSCode-win32-x64-1.26.0.zip" size="75159093" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=d153be282bb0b6d0371f9e4a6370056a65f998a3" main="Code.exe" released="2018-08-15" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="HQPY6AKCUY7KWYS5IFGAJPVT5NWBD36BRPJ45I4R6QFUYD6JYFTA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/4e9361845dc28659923a300945f84731393e210d/VSCode-win32-ia32-1.26.0.zip" size="66696693" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=dd1387d3214905c0b15f206329d1ebe08818657c" main="bin/code" released="2018-08-15" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="WT6XJAPYBV7NWN4LWPXYEEH2SWMQXYBVUE5PIKZOKC3XSV35YDVQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/4e9361845dc28659923a300945f84731393e210d/code-stable-1534177726.tar.gz" size="69776082" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=7754c32304dd438ae5ab8431d3637e46229b0935" main="bin/code" released="2018-08-15" stability="stable" version="1.26.0">
+      <manifest-digest sha256new="G3DKQWKMIH6ZGUSVJGHP4DVWVM24LYAN54SCJQTGRJITUS5YQTXA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/4e9361845dc28659923a300945f84731393e210d/code-stable-1534177733.tar.gz" size="72861878" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6a5746f93877efb8b227505dd2fed7b88034911c" main="Code.exe" released="2018-08-20" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="5EFQN7MRYLBSQ4SCM4ST46HHUHTXDTZ66MUUNOYBW7WXVBBQ5WIQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/493869ee8e8a846b0855873886fc79d480d342de/VSCode-win32-x64-1.26.1.zip" size="75157027" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=49ed060f138ba93a99ff51743da8948af914f287" main="Code.exe" released="2018-08-20" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="UIVVWQVPQJKH3TL25FBHEAWTM45GBZVMYFTUNEEBP7ULQGJPTQFQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/493869ee8e8a846b0855873886fc79d480d342de/VSCode-win32-ia32-1.26.1.zip" size="66763399" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=8059a3c1bb486a5f67fd1507a5256a7b526e0fdc" main="bin/code" released="2018-08-20" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="2GHCXJSXPD55A5X7FMFOKTGOJKEC6WZK6JE3FRINRHDJWNIVSIWA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/493869ee8e8a846b0855873886fc79d480d342de/code-stable-1534444642.tar.gz" size="69775652" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=fb753e11d440b888bbbcd96eb54deaa7c9828dc4" main="bin/code" released="2018-08-20" stability="stable" version="1.26.1">
+      <manifest-digest sha256new="7VXYRL5CTUOA76RAREAJRB3XEFED7B3ENJ3T3ZSKZBK74RNHBREA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/493869ee8e8a846b0855873886fc79d480d342de/code-stable-1534444635.tar.gz" size="72863476" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6f684f3b99f502453abc7b6d727567120648a305" main="Code.exe" released="2018-09-07" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="Q2NE2BBKVZXC5X2NN3UAWP6ENN5T3CVODUNTTIFRADRFKPHLLMCA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/7b9afc4196bda60b0facdf62cfc02815509b23d6/VSCode-win32-x64-1.27.0.zip" size="70044952" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=42b6d0a65dcb34d20f97bde6b0c8a7739acfcc3e" main="Code.exe" released="2018-09-07" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="6UDM2A2FFBETSAQ4HPR2PRFDWUHKK2SKNNSEMTTMIKULIFHRKNFQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/7b9afc4196bda60b0facdf62cfc02815509b23d6/VSCode-win32-ia32-1.27.0.zip" size="61379613" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=483d188b5ac530d1491487ec0df736e37e4ddf23" main="bin/code" released="2018-09-07" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="6UJIUDLDEJU6A3IYECMYQUC4L4VFCK5Y6UBLEP7DMWNQ2ISIMKRA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/7b9afc4196bda60b0facdf62cfc02815509b23d6/code-stable-1536125540.tar.gz" size="66445833" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=8aa4b883469cd8b301aefb88d056df3ee7322bb1" main="bin/code" released="2018-09-07" stability="stable" version="1.27.0">
+      <manifest-digest sha256new="F6YWTR23S324IPVZHNJ6XXG5X4NTVNVN6NYN6QXQAA3L7FZAMYCQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/7b9afc4196bda60b0facdf62cfc02815509b23d6/code-stable-1536125674.tar.gz" size="69492159" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=b595256e7206e5df9154c04c3bf4070ba98609bb" main="Code.exe" released="2018-09-07" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="AJ5XRH6BAJ5D3P6CRWUZAUH2VEUZL6TU7TALR2OBQIMFAOYLMYVA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/5944e81f3c46a3938a82c701f96d7a59b074cfdc/VSCode-win32-x64-1.27.1.zip" size="70035724" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=7ff5a29d747d1022ed1c35d3015166350dcf3de3" main="Code.exe" released="2018-09-07" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="YTZBKAAMLKGVJ46MXPF2MDXVG6ADDWOROOFVQ4ZN6DYMSIFHJ3KA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/5944e81f3c46a3938a82c701f96d7a59b074cfdc/VSCode-win32-ia32-1.27.1.zip" size="61387431" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=313f3d5b5f6c8bba13982ee0207716733de274c7" main="bin/code" released="2018-09-07" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="OV4NXVFCKWYQD3HFCJUZSJ64MOS7NSWMRPGVFWGEMO5UAWFNOB2Q"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/5944e81f3c46a3938a82c701f96d7a59b074cfdc/code-stable-1536225977.tar.gz" size="66446275" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=378318644037ad357cf279b326346b5df927653e" main="bin/code" released="2018-09-07" stability="stable" version="1.27.1">
+      <manifest-digest sha256new="LDTFK7MDDUY2J547SKQSOWYDNJZE3OS3TDT4J7HJTFHFSTBG6VWQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/5944e81f3c46a3938a82c701f96d7a59b074cfdc/code-stable-1536225976.tar.gz" size="69491072" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=6764714c7d9ca589788e49b43851333a55d71c74" main="Code.exe" released="2018-09-15" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="6NGV7KY7PFOS4DT6L74JAZ2O5A2XXPG55LN4ESOLAPVPWBSSWUAA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/f46c4c469d6e6d8c46f268d1553c5dc4b475840f/VSCode-win32-x64-1.27.2.zip" size="70045313" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=c1ae599e16c2bbe8788cacfbd79aca8683a9ef84" main="Code.exe" released="2018-09-15" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="HAO35ZDEW2DQZ4DQMKADPEWIMDS56G4CXGET6IKXSIG6KZU4FQ4A"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/f46c4c469d6e6d8c46f268d1553c5dc4b475840f/VSCode-win32-ia32-1.27.2.zip" size="61388660" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=3fb937f77d8f42fb7ffdc6d77f4d4a091b3a1c11" main="bin/code" released="2018-09-15" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="2FM3SE4SJRKX3AV3DBD4LLFTWJFBPHSIBYLLMOSYZU2N555XZEWA"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/f46c4c469d6e6d8c46f268d1553c5dc4b475840f/code-stable-1536736541.tar.gz" size="66446563" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=bddcbf587376a1ba4ede61e1316705838cd46cee" main="bin/code" released="2018-09-15" stability="stable" version="1.27.2">
+      <manifest-digest sha256new="FNS5LSXPBRQOYELTDPV7ELYJQVY4WY6FSRZHPFMQF5KDAXAVGFXA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/f46c4c469d6e6d8c46f268d1553c5dc4b475840f/code-stable-1536736544.tar.gz" size="69492248" type="application/x-compressed-tar"/>
+    </implementation>
+  </group>
+
+  <entry-point binary-name="code" command="run"/>
+
+  <capabilities xmlns="http://0install.de/schema/desktop-integration/capabilities">
+    <file-type id="VSCode.ascx">
+      <description>ASCX Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="application/xml" value=".ascx"/>
+    </file-type>
+    <file-type id="VSCode.asp">
+      <description>ASP Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".asp"/>
+    </file-type>
+    <file-type id="VSCode.aspx">
+      <description>ASPX Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="application/xml" perceived-type="text" value=".aspx"/>
+    </file-type>
+    <file-type id="VSCode.bash">
+      <description>Bash Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".bash"/>
+    </file-type>
+    <file-type id="VSCode.bashrc">
+      <description>Bash RC Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".bashrc"/>
+    </file-type>
+    <file-type id="VSCode.bash_login">
+      <description>Bash Login Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".bash_login"/>
+    </file-type>
+    <file-type id="VSCode.bash_logout">
+      <description>Bash Logout Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".bash_logout"/>
+    </file-type>
+    <file-type id="VSCode.bash_profile">
+      <description>Bash Profile Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".bash_profile"/>
+    </file-type>
+    <file-type id="VSCode.bowerrc">
+      <description>Bower RC Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".bowerrc"/>
+    </file-type>
+    <file-type id="VSCode.c">
+      <description>C Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".c"/>
+    </file-type>
+    <file-type id="VSCode.cc">
+      <description>C++ Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".cc"/>
+    </file-type>
+    <file-type id="VSCode.clj">
+      <description>Clojure Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".clj"/>
+    </file-type>
+    <file-type id="VSCode.cljs">
+      <description>ClojureScript Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".cljs"/>
+    </file-type>
+    <file-type id="VSCode.cljx">
+      <description>CLJX Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".cljx"/>
+    </file-type>
+    <file-type id="VSCode.clojure">
+      <description>Clojure Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".clojure"/>
+    </file-type>
+    <file-type id="VSCode.code-workspace">
+      <description>Code Workspace Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".code-workspace"/>
+    </file-type>
+    <file-type id="VSCode.coffee">
+      <description>CoffeeScript Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".coffee"/>
+    </file-type>
+    <file-type id="VSCode.config">
+      <description>Configuration Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="application/xml" value=".config"/>
+    </file-type>
+    <file-type id="VSCode.cpp">
+      <description>C++ Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".cpp"/>
+    </file-type>
+    <file-type id="VSCode.cs">
+      <description>C# Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".cs"/>
+    </file-type>
+    <file-type id="VSCode.cshtml">
+      <description>CSHTML Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".cshtml"/>
+    </file-type>
+    <file-type id="VSCode.csproj">
+      <description>C# Project Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" value=".csproj"/>
+    </file-type>
+    <file-type id="VSCode.css">
+      <description>CSS Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/css" perceived-type="text" value=".css"/>
+    </file-type>
+    <file-type id="VSCode.csx">
+      <description>C# Script Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".csx"/>
+    </file-type>
+    <file-type id="VSCode.ctp">
+      <description>CakePHP Template Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".ctp"/>
+    </file-type>
+    <file-type id="VSCode.cxx">
+      <description>C++ Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".cxx"/>
+    </file-type>
+    <file-type id="VSCode.dockerfile">
+      <description>Dockerfile Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".dockerfile"/>
+    </file-type>
+    <file-type id="VSCode.dot">
+      <description>Dot Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="application/msword" value=".dot"/>
+    </file-type>
+    <file-type id="VSCode.dtd">
+      <description>Document Type Definition Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="application/xml-dtd" value=".dtd"/>
+    </file-type>
+    <file-type id="VSCode.editorconfig">
+      <description>Editor Config Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".editorconfig"/>
+    </file-type>
+    <file-type id="VSCode.edn">
+      <description>Extensible Data Notation Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".edn"/>
+    </file-type>
+    <file-type id="VSCode.eyaml">
+      <description>Hiera Eyaml Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".eyaml"/>
+    </file-type>
+    <file-type id="VSCode.eyml">
+      <description>Hiera Eyaml Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".eyml"/>
+    </file-type>
+    <file-type id="VSCode.fs">
+      <description>F# Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".fs"/>
+    </file-type>
+    <file-type id="VSCode.fsi">
+      <description>F# Signature Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".fsi"/>
+    </file-type>
+    <file-type id="VSCode.fsscript">
+      <description>F# Script Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".fsscript"/>
+    </file-type>
+    <file-type id="VSCode.fsx">
+      <description>F# Script Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".fsx"/>
+    </file-type>
+    <file-type id="VSCode.gemspec">
+      <description>Gemspec Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".gemspec"/>
+    </file-type>
+    <file-type id="VSCode.gitattributes">
+      <description>Git Attributes Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".gitattributes"/>
+    </file-type>
+    <file-type id="VSCode.gitconfig">
+      <description>Git Config Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".gitconfig"/>
+    </file-type>
+    <file-type id="VSCode.gitignore">
+      <description>Git Ignore Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".gitignore"/>
+    </file-type>
+    <file-type id="VSCode.go">
+      <description>Go Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".go"/>
+    </file-type>
+    <file-type id="VSCode.h">
+      <description>C Header Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".h"/>
+    </file-type>
+    <file-type id="VSCode.handlebars">
+      <description>Handlebars Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".handlebars"/>
+    </file-type>
+    <file-type id="VSCode.hbs">
+      <description>Handlebars Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".hbs"/>
+    </file-type>
+    <file-type id="VSCode.hh">
+      <description>C++ Header Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".hh"/>
+    </file-type>
+    <file-type id="VSCode.hpp">
+      <description>C++ Header Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".hpp"/>
+    </file-type>
+    <file-type id="VSCode.htm">
+      <description>HTML Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/html" perceived-type="text" value=".htm"/>
+    </file-type>
+    <file-type id="VSCode.html">
+      <description>HTML Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/html" perceived-type="text" value=".html"/>
+    </file-type>
+    <file-type id="VSCode.hxx">
+      <description>C++ Header Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".hxx"/>
+    </file-type>
+    <file-type id="VSCode.ini">
+      <description>INI Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension perceived-type="text" value=".ini"/>
+    </file-type>
+    <file-type id="VSCode.jade">
+      <description>Jade Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".jade"/>
+    </file-type>
+    <file-type id="VSCode.jav">
+      <description>Java Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".jav"/>
+    </file-type>
+    <file-type id="VSCode.java">
+      <description>Java Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension perceived-type="text" value=".java"/>
+    </file-type>
+    <file-type id="VSCode.js">
+      <description>JavaScript Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".js"/>
+    </file-type>
+    <file-type id="VSCode.jscsrc">
+      <description>JSCS RC Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".jscsrc"/>
+    </file-type>
+    <file-type id="VSCode.jshintrc">
+      <description>JSHint RC Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".jshintrc"/>
+    </file-type>
+    <file-type id="VSCode.jshtm">
+      <description>JavaScript HTML Template Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".jshtm"/>
+    </file-type>
+    <file-type id="VSCode.json">
+      <description>JSON Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".json"/>
+    </file-type>
+    <file-type id="VSCode.jsp">
+      <description>Java Server Pages Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".jsp"/>
+    </file-type>
+    <file-type id="VSCode.less">
+      <description>LESS Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".less"/>
+    </file-type>
+    <file-type id="VSCode.lua">
+      <description>Lua Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".lua"/>
+    </file-type>
+    <file-type id="VSCode.m">
+      <description>Objective C Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".m"/>
+    </file-type>
+    <file-type id="VSCode.makefile">
+      <description>Makefile Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".makefile"/>
+    </file-type>
+    <file-type id="VSCode.markdown">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".markdown"/>
+    </file-type>
+    <file-type id="VSCode.md">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".md"/>
+    </file-type>
+    <file-type id="VSCode.mdoc">
+      <description>MDoc Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mdoc"/>
+    </file-type>
+    <file-type id="VSCode.mdown">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mdown"/>
+    </file-type>
+    <file-type id="VSCode.mdtext">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mdtext"/>
+    </file-type>
+    <file-type id="VSCode.mdtxt">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mdtxt"/>
+    </file-type>
+    <file-type id="VSCode.mdwn">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mdwn"/>
+    </file-type>
+    <file-type id="VSCode.mkd">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mkd"/>
+    </file-type>
+    <file-type id="VSCode.mkdn">
+      <description>Markdown Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mkdn"/>
+    </file-type>
+    <file-type id="VSCode.ml">
+      <description>OCaml Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".ml"/>
+    </file-type>
+    <file-type id="VSCode.mli">
+      <description>OCaml Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".mli"/>
+    </file-type>
+    <file-type id="VSCode.npmignore">
+      <description>NPM Ignore Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".npmignore"/>
+    </file-type>
+    <file-type id="VSCode.php">
+      <description>PHP Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".php"/>
+    </file-type>
+    <file-type id="VSCode.phtml">
+      <description>PHP HTML Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".phtml"/>
+    </file-type>
+    <file-type id="VSCode.pl">
+      <description>Perl Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension perceived-type="text" value=".pl"/>
+    </file-type>
+    <file-type id="VSCode.pl6">
+      <description>Perl 6 Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".pl6"/>
+    </file-type>
+    <file-type id="VSCode.pm">
+      <description>Perl Module Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".pm"/>
+    </file-type>
+    <file-type id="VSCode.pm6">
+      <description>Perl 6 Module Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".pm6"/>
+    </file-type>
+    <file-type id="VSCode.pod">
+      <description>Perl POD Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".pod"/>
+    </file-type>
+    <file-type id="VSCode.pp">
+      <description>Perl Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".pp"/>
+    </file-type>
+    <file-type id="VSCode.profile">
+      <description>Profile Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".profile"/>
+    </file-type>
+    <file-type id="VSCode.properties">
+      <description>Properties Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".properties"/>
+    </file-type>
+    <file-type id="VSCode.ps1">
+      <description>PowerShell Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".ps1"/>
+    </file-type>
+    <file-type id="VSCode.psd1">
+      <description>PowerShell Module Manifest Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".psd1"/>
+    </file-type>
+    <file-type id="VSCode.psgi">
+      <description>Perl CGI Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".psgi"/>
+    </file-type>
+    <file-type id="VSCode.psm1">
+      <description>PowerShell Module Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".psm1"/>
+    </file-type>
+    <file-type id="VSCode.py">
+      <description>Python Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".py"/>
+    </file-type>
+    <file-type id="VSCode.r">
+      <description>R Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".r"/>
+    </file-type>
+    <file-type id="VSCode.rb">
+      <description>Ruby Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".rb"/>
+    </file-type>
+    <file-type id="VSCode.rhistory">
+      <description>R History Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".rhistory"/>
+    </file-type>
+    <file-type id="VSCode.rprofile">
+      <description>R Profile Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".rprofile"/>
+    </file-type>
+    <file-type id="VSCode.rs">
+      <description>Rust Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".rs"/>
+    </file-type>
+    <file-type id="VSCode.rt">
+      <description>Rich Text Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".rt"/>
+    </file-type>
+    <file-type id="VSCode.scss">
+      <description>Sass Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".scss"/>
+    </file-type>
+    <file-type id="VSCode.sh">
+      <description>SH Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".sh"/>
+    </file-type>
+    <file-type id="VSCode.shtml">
+      <description>SHTML Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/html" perceived-type="text" value=".shtml"/>
+    </file-type>
+    <file-type id="VSCode.sql">
+      <description>SQL Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".sql"/>
+    </file-type>
+    <file-type id="VSCode.svg">
+      <description>SVG Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="image/svg+xml" value=".svg"/>
+    </file-type>
+    <file-type id="VSCode.svgz">
+      <description>SVGZ Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".svgz"/>
+    </file-type>
+    <file-type id="VSCode.t">
+      <description>Perl Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".t"/>
+    </file-type>
+    <file-type id="VSCode.tex">
+      <description>LaTeX Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".tex"/>
+    </file-type>
+    <file-type id="VSCode.ts">
+      <description>TypeScript Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".ts"/>
+    </file-type>
+    <file-type id="VSCode.txt">
+      <description>Text Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".txt"/>
+    </file-type>
+    <file-type id="VSCode.vb">
+      <description>Visual Basic Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/plain" perceived-type="text" value=".vb"/>
+    </file-type>
+    <file-type id="VSCode.wxi">
+      <description>WiX Include Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".wxi"/>
+    </file-type>
+    <file-type id="VSCode.wxl">
+      <description>WiX Localization Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".wxl"/>
+    </file-type>
+    <file-type id="VSCode.wxs">
+      <description>WiX Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".wxs"/>
+    </file-type>
+    <file-type id="VSCode.xaml">
+      <description>XAML Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="application/xaml+xml" value=".xaml"/>
+    </file-type>
+    <file-type id="VSCode.xml">
+      <description>XML Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension mime-type="text/xml" perceived-type="text" value=".xml"/>
+    </file-type>
+    <file-type id="VSCode.yaml">
+      <description>Yaml Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".yaml"/>
+    </file-type>
+    <file-type id="VSCode.yml">
+      <description>Yaml Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".yml"/>
+    </file-type>
+    <file-type id="VSCode.zsh">
+      <description>ZSH Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+      <extension value=".zsh"/>
+    </file-type>
+    <file-type id="VSCodeSourceFile">
+      <description>Visual Studio Code Source File</description>
+      <icon href="http://0install.de/feed-icons/VS_Code_File.ico" type="image/vnd.microsoft.icon" xmlns="http://zero-install.sourceforge.net/2004/injector/interface"/>
+      <verb args="&quot;%1&quot;" name="open"/>
+    </file-type>
+    <context-menu id="files-VSCode">
+      <verb args="&quot;%1&quot;" name="VSCode">
+        <description>Open with C&amp;ode</description>
+      </verb>
+    </context-menu>
+    <context-menu id="directories-VSCode" target="directories">
+      <verb args="&quot;%V&quot;" name="VSCode">
+        <description>Open with C&amp;ode</description>
+      </verb>
+    </context-menu>
+  </capabilities>
+</interface>

--- a/editors/vs-code.xml.template
+++ b/editors/vs-code.xml.template
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Visual Studio Code</name>
+  <summary>lightweight but powerful source code editor</summary>
+  <description>Visual Studio Code is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, macOS and Linux. It comes with built-in support for JavaScript, TypeScript and Node.js and has a rich ecosystem of extensions for other languages (such as C++, C#, Python, PHP, Go) and runtimes (such as .NET and Unity).</description>
+  <homepage>https://code.visualstudio.com/</homepage>
+  <icon href="http://0install.de/feed-icons/VS_Code.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="http://0install.de/feed-icons/VS_Code.png" type="image/png"/>
+  <category>Development</category>
+  <category>Utility</category>
+
+  <feed-for interface="http://repo.roscidus.com/editors/vs-code"/>
+
+  <group license="MIT License">
+    <implementation arch="Windows-x86_64" main="Code.exe" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive href="https://az764295.vo.msecnd.net/stable/{release-id}/VSCode-win32-x64-{version}.zip" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" main="Code.exe" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive href="https://az764295.vo.msecnd.net/stable/{release-id}/VSCode-win32-ia32-{version}.zip" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" main="bin/code" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/{release-id}/code-stable-{linux-amd64-timestamp}.tar.gz" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" main="bin/code" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/{release-id}/code-stable-{linux-i386-timestamp}.tar.gz" type="application/x-compressed-tar"/>
+    </implementation>
+    <!--<implementation arch="MacOSX-*" main="Contents/MacOS/Electron" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="Visual Studio Code.app" href="https://az764295.vo.msecnd.net/stable/{release-id}/VSCode-darwin-stable.zip" type="application/zip"/>
+    </implementation>-->
+  </group>
+</interface>

--- a/security/nmap.watch.py
+++ b/security/nmap.watch.py
@@ -1,0 +1,6 @@
+from urllib import request
+import re
+
+data = request.urlopen('http://nmap.org/dist/').read().decode('utf-8')
+matches = re.findall(r'nmap-([0-9\.]+)-win32.zip</a></td><td align="right">(....-..-..)', data)
+releases = [{'version': match[0], 'released': match[1]} for match in matches if not match[0].startswith('2.0')]

--- a/security/nmap.xml
+++ b/security/nmap.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/security/nmap" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Nmap</name>
+  <summary>utility for network discovery and security auditing</summary>
+  <description>Nmap (Network Mapper) is a free and open source utility for network discovery and security auditing. Many systems and network administrators also find it useful for tasks such as network inventory, managing service upgrade schedules, and monitoring host or service uptime. Nmap uses raw IP packets in novel ways to determine what hosts are available on the network, what services (application name and version) those hosts are offering, what operating systems (and OS versions) they are running, what type of packet filters/firewalls are in use, and dozens of other characteristics. It was designed to rapidly scan large networks, but works fine against single hosts.</description>
+  <icon href="http://0install.de/feed-icons/Nmap.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="http://0install.de/feed-icons/Nmap.png" type="image/png"/>
+  <category>Network</category>
+  <category>Utility</category>
+  <needs-terminal/>
+
+  <package-implementation main="/usr/bin/nmap" package="nmap"/>
+
+  <group arch="Windows-*" license="modfied GPL">
+    <requires interface="http://0install.de/feeds/MSVC100.xml">
+      <environment name="PATH" insert="." mode="append"/>
+    </requires>
+    <command name="run" path="nmap.exe"/>
+    <command name="ncat" path="ncat.exe"/>
+    <command name="nping" path="nping.exe"/>
+    <command name="ndiff" path="ndiff.py">
+      <runner interface="http://repo.roscidus.com/python/python" version="2.6..!3"/>
+    </command>
+    <implementation id="sha1new=71dcf94b6c2a0ebd50f58278302725eb8e7929e9" released="2013-04-12" stability="stable" version="6.00">
+      <manifest-digest sha256new="SL7UMYQGIQD372PPHEE7I75EXD6EDLBMWSXH6PVOKNNTF5WHMVIQ"/>
+      <archive extract="nmap-6.00" href="http://nmap.org/dist/nmap-6.00-win32.zip" size="19193787" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=4c057fc03dc624ed22c8028c01e02ca14c295ad5" released="2013-04-12" stability="stable" version="6.01">
+      <manifest-digest sha256new="MLPFLZEVAU5PLCGST4LN6PVWG4GZIOIBFDHEIDNQ5NJQPZTWY7UQ"/>
+      <archive extract="nmap-6.01" href="http://nmap.org/dist/nmap-6.01-win32.zip" size="19191884" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=1f3b9546920a78079251e433d39075c2282afccc" released="2013-04-12" stability="stable" version="6.25">
+      <manifest-digest sha256new="NCPXDNATODIAK3TPOPT2LGFI4HUW6UYFI7OOAGVVCVBP757EMJLA"/>
+      <archive extract="nmap-6.25" href="http://nmap.org/dist/nmap-6.25-win32.zip" size="19646416" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=0a9d505d17802cee8040a3629c8d6a1c8354e82f" released="2013-07-28" stability="stable" version="6.40">
+      <manifest-digest sha256new="XVIMAIR2FZZOQP7EEBTBRF5R4JFJFXJ74HB5545L3RPSJ6YY54AA"/>
+      <archive extract="nmap-6.40" href="http://nmap.org/dist/nmap-6.40-win32.zip" size="19863449" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=f36315daed74ead5e88a1eeca4d6d31c0d709e7e" released="2014-04-12" stability="stable" version="6.45">
+      <manifest-digest sha256new="OBS3BZ4JERVN5TZCLLYKSN4VPSGPNLBG33FVCGPCNNBUO7NYXBWQ"/>
+      <archive extract="nmap-6.45" href="http://nmap.org/dist/nmap-6.45-win32.zip" size="19960772" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=3fb8d90c6a5ae57a201ca97fdae6827d0820a698" released="2014-04-17" stability="stable" version="6.46">
+      <manifest-digest sha256new="WAOBFM7BRYKJIY4QQ65EGIQKJOHSWK3SLXXCEI6YUE2EGR7NSS5Q"/>
+      <archive extract="nmap-6.46" href="http://nmap.org/dist/nmap-6.46-win32.zip" size="19961033" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=7eb8207633ff66085220788ab9e39f7c63e0fb62" released="2014-08-22" stability="stable" version="6.47">
+      <manifest-digest sha256new="MH2JFSDIS75VIK562GFRKJOZ4SPCLUFPF7UD27MXXNL35Q6F5EUA"/>
+      <archive extract="nmap-6.47" href="http://nmap.org/dist/nmap-6.47-win32.zip" size="20002559" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=f05e503c7ce69770144357e7fa3742578f5904ce" released="2015-11-19" stability="stable" version="7.00">
+      <manifest-digest sha256new="I2WGGP2U2PGTLXN2RCVJCOVXH3YRBUUGJAAGD3Y4LL7KKEWWR7IQ"/>
+      <archive extract="nmap-7.00" href="http://nmap.org/dist/nmap-7.00-win32.zip" size="18725194" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=0a47e384eac986d5026f219be9cfdb2cf9ec51a8" released="2015-12-09" stability="stable" version="7.01">
+      <manifest-digest sha256new="V2ZKZC3MB2ZDF4H7FFVPTMQIADBPB7SFAHCYGJOHN2NTOO3XEO3A"/>
+      <archive extract="nmap-7.01" href="http://nmap.org/dist/nmap-7.01-win32.zip" size="18727987" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=32ffb8e43fdef4b6dc50cf7d796dcd90bd2a9e69" released="2016-03-17" stability="stable" version="7.10">
+      <manifest-digest sha256new="MGE4RRVVS47VUQ45LIJCWCXJPCMJS3SIPSNTMYOUPNPT6QXW5DKA"/>
+      <archive extract="nmap-7.10" href="http://nmap.org/dist/nmap-7.10-win32.zip" size="14340565" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=732a5b2a0a635966adec62b694da097087d7b57b" released="2016-03-22" stability="stable" version="7.11">
+      <manifest-digest sha256new="OWS4ROH6BHPARMJEMPOBRYLSY4VB5CANWM6Y6XMFM7XLTKWCX3MA"/>
+      <archive extract="nmap-7.11" href="http://nmap.org/dist/nmap-7.11-win32.zip" size="14344226" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=c5ddd44e0cd414fe4b72e745be049c4f036f4e3d" released="2016-03-29" stability="stable" version="7.12">
+      <manifest-digest sha256new="YWTIE5VRXT3NP5A33R2OH7MDMKP2IETYTE5YCIRSXYFB6QQLWADQ"/>
+      <archive extract="nmap-7.12" href="http://nmap.org/dist/nmap-7.12-win32.zip" size="14346005" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=3299d812eb08b62eb2931de5d01817c549847ea4" released="2016-09-29" stability="stable" version="7.30">
+      <manifest-digest sha256new="N45SZLJU5CD5FSILCNVP7AULQLF2O6V67Y5DDD34XXI4GEY7QIVQ"/>
+      <archive extract="nmap-7.30" href="http://nmap.org/dist/nmap-7.30-win32.zip" size="19635543" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=29b9bb0f23dbce11547b0dbdbfc37d4bc6dd22cb" released="2016-10-20" stability="stable" version="7.31">
+      <manifest-digest sha256new="3E7HWDR6D5VN4PFMREDTNHPHZDU6DF5I6MJNDKBLI4E75PXANEWQ"/>
+      <archive extract="nmap-7.31" href="http://nmap.org/dist/nmap-7.31-win32.zip" size="19652284" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=d6ef836e2b156d893db6f2103135df1aaf0650cc" released="2016-12-20" stability="stable" version="7.40">
+      <manifest-digest sha256new="KYG2OKTVDQEZBOCRP7WOURUIMHO6AMMCE2SPWQNKIEEIYCY73XHQ"/>
+      <archive extract="nmap-7.40" href="http://nmap.org/dist/nmap-7.40-win32.zip" size="19486026" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=5dbd0c8e77bdb51fa8fba34dd2ed6c52aec76fcb" released="2017-06-13" stability="stable" version="7.50">
+      <manifest-digest sha256new="42NT2NB2HZNBMRIDRJOY77WOFATWNI6BDUASRHUYTWLZ7RXEC7UQ"/>
+      <archive extract="nmap-7.50" href="http://nmap.org/dist/nmap-7.50-win32.zip" size="19740464" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=3fcbaa90ffb87bde0a55f621e03a4efb4a83a0fb" released="2017-08-01" stability="stable" version="7.60">
+      <manifest-digest sha256new="SSVMLFHSENHSA3DYIDQPOXPGDSTATV46NBJOE5ITU5G722KVAMWA"/>
+      <archive extract="nmap-7.60" href="http://nmap.org/dist/nmap-7.60-win32.zip" size="19873849" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=bc61116d60dcea3fc885e74d6c5c0101cfb23fe4" released="2018-03-20" stability="stable" version="7.70">
+      <manifest-digest sha256new="HADOSECAAM5D5P4K5GVY3BDFICAPJ5V55WXA7FTMYFACTQXUSHRA"/>
+      <archive extract="nmap-7.70" href="http://nmap.org/dist/nmap-7.70-win32.zip" size="20111852" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group doc-dir="usr/share/doc/nmap" license="modfied GPL">
+    <requires interface="http://repo.roscidus.com/lib/svn-client-1">
+      <environment insert="lib" name="LD_LIBRARY_PATH"/>
+    </requires>
+    <command name="run" path="usr/bin/nmap"/>
+    <command name="ndiff" path="usr/lib/python2.6/site-packages/ndiff.py">
+      <runner interface="http://repo.roscidus.com/python/python" version="2.6..!3"/>
+    </command>
+    <implementation arch="Linux-x86_64" id="sha1new=dc57eecac58f2d5ee867a29b86f37530f6436cf0" released="2013-04-12" stability="stable" version="6.00-1">
+      <manifest-digest sha256new="FMRA5OYMGSANUMQPKKSBC4OT3QIQHCWL4XM7YQY4SBWIEQIH536A"/>
+      <archive href="http://nmap.org/dist/nmap-6.00-1.x86_64.rpm" size="4489523" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=82c563d6d342c3a520a052c9df60ba9bf0a0d3a4" released="2013-04-12" stability="stable" version="6.00-1">
+      <manifest-digest sha256new="64JIW36PZBED2IDIXUCRFGRDHEOMD7FNL6QD7Q57NE2CYJX26OCQ"/>
+      <archive href="http://nmap.org/dist/nmap-6.00-1.i386.rpm" size="4421785" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=bd7470620998fe6e988467c82c424898d52ff84e" released="2013-04-12" stability="stable" version="6.01-1">
+      <manifest-digest sha256new="N2LWCXXNJ2KSQ7NRK2ZBUFXUDGFP5A7VSQOAWR5J54LRZSU4MW3Q"/>
+      <archive href="http://nmap.org/dist/nmap-6.01-1.x86_64.rpm" size="4489560" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=87ed80f61eada030df4b4b9ae83a6a25a0b36f68" released="2013-04-12" stability="stable" version="6.01-1">
+      <manifest-digest sha256new="O7BVSTJWKEIQMC2V6XO4OMALOYAECPAABPGIM5FHFXJN6ZBFXNJQ"/>
+      <archive href="http://nmap.org/dist/nmap-6.01-1.i386.rpm" size="4421945" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=aacaf6add0bc909c59c6747c5ea8defbbfff0fce" released="2013-04-12" stability="stable" version="6.25-1">
+      <manifest-digest sha256new="UEEPM7TUMLRLU3KDIQQUFRJAWMIVAMCOLWM7WTNNMD4JKN6WRSKA"/>
+      <archive href="http://nmap.org/dist/nmap-6.25-1.x86_64.rpm" size="4879319" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=04c39767ca12ae683b82b71fa7f3fba32d464850" released="2013-04-12" stability="stable" version="6.25-1">
+      <manifest-digest sha256new="XJMNM5HU6SE5BXZQ426CKSAUVJIVHHXK34KW6H33ZTY6ZAXUG5WA"/>
+      <archive href="http://nmap.org/dist/nmap-6.25-1.i386.rpm" size="4812345" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=a4bd83c31adbbe292f14b71c55ad86b2383c62b0" released="2013-07-28" stability="stable" version="6.40-1">
+      <manifest-digest sha256new="NPXY4TXHWMOGCBLHLN22EI27RATSEKHXQMADFWCY3NBZLKFUIZ2A"/>
+      <archive href="http://nmap.org/dist/nmap-6.40-1.x86_64.rpm" size="5007717" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=7f2d1f506a7939187ef8a534c86860623e5a6c5c" released="2013-07-28" stability="stable" version="6.40-1">
+      <manifest-digest sha256new="I3JWCQUMACQNWDBSE3PRLJ2HYULV23OTQNYTOTXDSR2RUAYKU2DQ"/>
+      <archive href="http://nmap.org/dist/nmap-6.40-1.i386.rpm" size="4940913" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=08fba64a574a62545b73485d5b1e1a1d006d87c0" released="2014-04-12" stability="stable" version="6.45-1">
+      <manifest-digest sha256new="R2AIFIUDOV6QB22DEPNMXXCLPJ5ZMDSKSQCAAOLBWBT7LJRDIMLQ"/>
+      <archive href="http://nmap.org/dist/nmap-6.45-1.x86_64.rpm" size="5086481" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=9b90e2e8d5124d815825bd384e1e5a39d21238f5" released="2014-04-12" stability="stable" version="6.45-1">
+      <manifest-digest sha256new="YT4KEI6CLIOQSHV4V4PBPYACSHVHB2DT5ANP637GNMHO3YAYA5UA"/>
+      <archive href="http://nmap.org/dist/nmap-6.45-1.i386.rpm" size="5015284" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=b30bac4aba440363b9df27de4e8dc8f734866373" released="2014-04-17" stability="stable" version="6.46-1">
+      <manifest-digest sha256new="KOMY66PS7A6LLQE2KX6X37X3WILAYOGOHDTUADUPLKHWW22FFERA"/>
+      <archive href="http://nmap.org/dist/nmap-6.46-1.x86_64.rpm" size="5086577" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=2d0ffef701028c350e75741dc7f2262270d174e7" released="2014-04-17" stability="stable" version="6.46-1">
+      <manifest-digest sha256new="WPQSACE3EDLT2765SLS6LJT7FH2TNVBB5VHG7HL32MTB3MSS75RQ"/>
+      <archive href="http://nmap.org/dist/nmap-6.46-1.i386.rpm" size="5015368" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=7e2ce9f5b7c9e0553d84e8ae57a5c6bef989ec1a" released="2014-08-22" stability="stable" version="6.47-1">
+      <manifest-digest sha256new="TJQE5UVJHHBHGHY2FRTHV55347I3PPRY7J7VQ4YOXBIUFP5BTG4A"/>
+      <archive href="http://nmap.org/dist/nmap-6.47-1.x86_64.rpm" size="5316443" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=642baef80da73589ef95e9748939e1df7e1199ef" released="2014-08-22" stability="stable" version="6.47-1">
+      <manifest-digest sha256new="TTCARAAC6EG4K6FO2F6VSPXYD4XOMDDLTH5OMZAT4KTFGSIPOGVA"/>
+      <archive href="http://nmap.org/dist/nmap-6.47-1.i386.rpm" size="5216735" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=e0e8ae511d0cb61e6a10e13d20b8e1ca833bc279" released="2015-11-19" stability="stable" version="7.00-1">
+      <manifest-digest sha256new="KDIWDUMWZKEZY4UNPQOJZBXB6LGY2MX4KXCINCEZCRM4OFL45BOA"/>
+      <archive href="http://nmap.org/dist/nmap-7.00-1.x86_64.rpm" size="6234124" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=ba6e6ba56f3baa7cf8fa06b709b2afa6ef4e7e60" released="2015-11-19" stability="stable" version="7.00-1">
+      <manifest-digest sha256new="RSVP3H5VWLX5GZVL2J7ZXRDXK7ICFWMGZDKEA2XIGFDU6JUEBMGQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.00-1.i686.rpm" size="5958392" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=8f46aafda7440d403b778427db666b7ddf77a08e" released="2015-12-09" stability="stable" version="7.01-1">
+      <manifest-digest sha256new="EBSRTZWKDSGTOCB6EB2OABMQM6DYMLO3YHA5UKXN3AJVINWX3AOA"/>
+      <archive href="http://nmap.org/dist/nmap-7.01-1.x86_64.rpm" size="6235492" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=4e95632a09be94fc0a4db2e8792d8fd8f13b6a91" released="2015-12-09" stability="stable" version="7.01-1">
+      <manifest-digest sha256new="VDVBYMURGDPJYEC76JJSAXUPMOHKR7SUZOAWI5VUJKCCMVUNI5MQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.01-1.i686.rpm" size="5959328" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=f5182f535355ce11ff8d29ee5eb6e3e062b47d8b" released="2016-03-17" stability="stable" version="7.10-1">
+      <manifest-digest sha256new="G3H52UOHT4PUEXU2NVHSE4ZZMUNZZC7N4WV4IBPV5VLFRLLHKMWA"/>
+      <archive href="http://nmap.org/dist/nmap-7.10-1.x86_64.rpm" size="6291244" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=a432f0262b0bea8ccdd658e9b8e6f237c7bd6957" released="2016-03-17" stability="stable" version="7.10-1">
+      <manifest-digest sha256new="SXD3IVSO7AKTDZY47SGQV2JHBMYCPLNL2DOHGB26R6KAIA5MC4HQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.10-1.i686.rpm" size="6013536" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=178f55b8e2aafa99c94a995392c120ebfc6f24ab" released="2016-03-22" stability="stable" version="7.11-1">
+      <manifest-digest sha256new="SYQFALPRMYXZXXDR5VG7MHAMNX35SZP4QSRFCW5KL5YUZIGSKO5Q"/>
+      <archive href="http://nmap.org/dist/nmap-7.11-1.x86_64.rpm" size="6294304" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=e87de7ff6d37cf9631ba487c07efb5beb7879c31" released="2016-03-22" stability="stable" version="7.11-1">
+      <manifest-digest sha256new="ZZC2KRTZKYEHZYQPJNKRXE5OYZTIAMBD4NC6LJUQW6NTKTMKPF5Q"/>
+      <archive href="http://nmap.org/dist/nmap-7.11-1.i686.rpm" size="6016532" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=e83dd958bd7297a2c65dfaaa0d5a595990bc9158" released="2016-03-29" stability="stable" version="7.12-1">
+      <manifest-digest sha256new="FPK57PIQREMHX7NALLP5YXIFERK6CKD3RZDNA3A2AJMEA6GUBRKQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.12-1.x86_64.rpm" size="6295792" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=dbd4cc586052fac1e1c41f77c502200d6597ff9d" released="2016-03-29" stability="stable" version="7.12-1">
+      <manifest-digest sha256new="JN4G6HPVHORBEOECFUTKU5ZABZVQDGEWKM77Z722QSDIYNNGWIPQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.12-1.i686.rpm" size="6018064" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=566ab7bd4d48aeb683363cab21a93f9f77ca93c2" released="2016-09-29" stability="stable" version="7.30-1">
+      <manifest-digest sha256new="TYXEA76HEY6UPPGULGUI6BJUO4XCTC5U7XSTJK6SP7QAEWWTSEWA"/>
+      <archive href="http://nmap.org/dist/nmap-7.30-1.x86_64.rpm" size="6500096" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=c4a17177caecf176b851b7570a70061a213089d5" released="2016-09-29" stability="stable" version="7.30-1">
+      <manifest-digest sha256new="LTDSBNS63SPY6KGIKWCZOMNO6ZXBUVJWUGXDGA42TKHBAUCE5RPA"/>
+      <archive href="http://nmap.org/dist/nmap-7.30-1.i686.rpm" size="6237756" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=10b07112b66e39399664924d06dfba0b06caf3ac" released="2016-10-20" stability="stable" version="7.31-1">
+      <manifest-digest sha256new="CEOAR2J5YFC7L67DCRDP6BRYO25GV6V4SBZTUPQ2OIQIH47LTNQQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.31-1.x86_64.rpm" size="6500252" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=cf247b466bab7ea7bcaf8ad426c3c72e64a923f2" released="2016-10-20" stability="stable" version="7.31-1">
+      <manifest-digest sha256new="E5JBGAWG2YJ4PNTT6IANH4LOEQQ3DBLX7L6CTY7PV2BQ4TOVDCVA"/>
+      <archive href="http://nmap.org/dist/nmap-7.31-1.i686.rpm" size="6237972" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=0935b06f33132286497258ddb3d77363c0925d2a" released="2016-12-20" stability="stable" version="7.40-1">
+      <manifest-digest sha256new="3KKXPE3Z2W6C4OZSW4GUB7I5Y52XMM5U4N5M3MC6A6VB2455Y7LQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.40-1.x86_64.rpm" size="6580316" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=b1e619544e1cf731b729cf2901657927cacdfe18" released="2016-12-20" stability="stable" version="7.40-1">
+      <manifest-digest sha256new="3CDIDQYJANSUALYZFV3MRJYEXDSQ6YGUNQ5KFINP7OK5AKFMYHCA"/>
+      <archive href="http://nmap.org/dist/nmap-7.40-1.i686.rpm" size="6318156" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=9a03bf3b220fa7b3c5befdc817536505238a98ae" released="2017-06-13" stability="stable" version="7.50-1">
+      <manifest-digest sha256new="ZNPTODLJDX4NFCWH3GPZSXSN4CLSZJXRFLWPFZORGQQ3LK7ISWBQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.50-1.x86_64.rpm" size="6806236" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=a76f14ecb4a7c6c76f5b171f61a6b08c28f17698" released="2017-06-13" stability="stable" version="7.50-1">
+      <manifest-digest sha256new="MQBHQSLASMRSEOLUDE3YIG2IHRJE325NX3AW2HECJK7MTXQPKFLA"/>
+      <archive href="http://nmap.org/dist/nmap-7.50-1.i686.rpm" size="6544532" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=e22b940d42c00b4dd22d23564e7c6299440513f1" released="2017-08-01" stability="stable" version="7.60-1">
+      <manifest-digest sha256new="ZTVRV3QK3JA2SFIRBYLSSWX5K45DRUI3CNR5WPWPVP3LW36FNP4A"/>
+      <archive href="http://nmap.org/dist/nmap-7.60-1.x86_64.rpm" size="6963200" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=03a144d2457f8c2a89e9309a9cb12dcbf10f2d18" released="2017-08-01" stability="stable" version="7.60-1">
+      <manifest-digest sha256new="D7TMRB2OBSXOC7U3YM4LM4XHCADY274O62RLOH2NULQRRC4AGL6A"/>
+      <archive href="http://nmap.org/dist/nmap-7.60-1.i686.rpm" size="6696672" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=68a2bf3f1948c892645ceffc03174814a593fba9" released="2018-03-20" stability="stable" version="7.70-1">
+      <manifest-digest sha256new="THBTVT677NGVNQPCAZSNHAJOPI3E3AXBYSN4N4CPS6XRRLWHWGOQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.70-1.x86_64.rpm" size="7116160" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" id="sha1new=aba452156f2453c2a64b4ce51ee1d3281ca4ea67" released="2018-03-20" stability="stable" version="7.70-1">
+      <manifest-digest sha256new="H23XG3KN2ICUJMAO3IJP64SU3FPZHY4UMDJWSQDHDW4Y3H5754GQ"/>
+      <archive href="http://nmap.org/dist/nmap-7.70-1.i686.rpm" size="6850972" type="application/x-rpm"/>
+    </implementation>
+  </group>
+
+  <entry-point binary-name="nmap" command="run">
+    <needs-terminal/>
+  </entry-point>
+  <entry-point binary-name="ncat" command="ncat">
+    <needs-terminal/>
+    <name>Ncat</name>
+    <summary>reads and writes data across networks from the command line</summary>
+    <description>Ncat is a feature-packed networking utility which reads and writes data across networks from the command line. Ncat was written for the Nmap Project as a much-improved reimplementation of the venerable Netcat. It uses both TCP and UDP for communication and is designed to be a reliable back-end tool to instantly provide network connectivity to other applications and users. Ncat will not only work with IPv4 and IPv6 but provides the user with a virtually limitless number of potential uses.</description>
+  </entry-point>
+  <entry-point binary-name="nping" command="nping">
+    <needs-terminal/>
+    <name>Nping</name>
+    <summary>network packet generation tool / ping utiliy</summary>
+    <description>Nping is an open source tool for network packet generation, response analysis and response time measurement. Nping can generate network packets for a wide range of protocols, allowing users full control over protocol headers. While Nping can be used as a simple ping utility to detect active hosts, it can also be used as a raw packet generator for network stack stress testing, ARP poisoning, Denial of Service attacks, route tracing, etc. Nping's novel echo mode lets users see how packets change in transit between the source and destination hosts. That's a great way to understand firewall rules, detect packet corruption, and more.</description>
+  </entry-point>
+  <entry-point binary-name="ndiff" command="ndiff">
+    <needs-terminal/>
+    <name>Ndiff</name>
+    <summary>a utility for comparing Nmap scan results</summary>
+    <description>Ndiff is a tool to aid in the comparison of Nmap scans. Specifically, it takes two Nmap XML output files and prints the differences between them: hosts coming up and down, ports becoming open or closed, and things like that. Ndiff can produce output in human-readable text or machine-readable XML formats. Many people like to scan their networks regularly (daily, weekly, etc.) and then use ndiff to easily detect any changes.</description>
+  </entry-point>
+</interface>

--- a/security/nmap.xml.template
+++ b/security/nmap.xml.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Nmap</name>
+  <summary>utility for network discovery and security auditing</summary>
+  <description>Nmap (Network Mapper) is a free and open source utility for network discovery and security auditing. Many systems and network administrators also find it useful for tasks such as network inventory, managing service upgrade schedules, and monitoring host or service uptime. Nmap uses raw IP packets in novel ways to determine what hosts are available on the network, what services (application name and version) those hosts are offering, what operating systems (and OS versions) they are running, what type of packet filters/firewalls are in use, and dozens of other characteristics. It was designed to rapidly scan large networks, but works fine against single hosts.</description>
+  <icon href="http://0install.de/feed-icons/Nmap.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="http://0install.de/feed-icons/Nmap.png" type="image/png"/>
+  <category>Network</category>
+  <category>Utility</category>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/security/nmap"/>
+
+  <group arch="Windows-*" license="modfied GPL">
+    <requires interface="http://0install.de/feeds/MSVC100.xml">
+      <environment name="PATH" insert="." mode="append"/>
+    </requires>
+    <command name="run" path="nmap.exe"/>
+    <command name="ncat" path="ncat.exe"/>
+    <command name="nping" path="nping.exe"/>
+    <command name="ndiff" path="ndiff.py">
+      <runner interface="http://repo.roscidus.com/python/python" version="2.6..!3"/>
+    </command>
+    <implementation version="{version}" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://nmap.org/dist/nmap-{version}-win32.zip" type="application/zip" extract="nmap-{version}"/>
+    </implementation>
+  </group>
+
+  <group doc-dir="usr/share/doc/nmap" license="modfied GPL">
+    <requires interface="http://repo.roscidus.com/lib/svn-client-1">
+      <environment insert="lib" name="LD_LIBRARY_PATH"/>
+    </requires>
+    <command name="run" path="usr/bin/nmap"/>
+    <command name="ndiff" path="usr/lib/python2.6/site-packages/ndiff.py">
+      <runner interface="http://repo.roscidus.com/python/python" version="2.6..!3"/>
+    </command>
+    <implementation arch="Linux-x86_64" version="{version}-1" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://nmap.org/dist/nmap-{version}-1.x86_64.rpm" type="application/x-rpm"/>
+    </implementation>
+    <implementation arch="Linux-i686" version="{version}-1" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://nmap.org/dist/nmap-{version}-1.i686.rpm" type="application/x-rpm"/>
+    </implementation>
+  </group>
+</interface>

--- a/utils/fixparts.watch.py
+++ b/utils/fixparts.watch.py
@@ -1,0 +1,6 @@
+from urllib import request
+import re
+
+data = request.urlopen('https://sourceforge.net/projects/gptfdisk/files/gptfdisk/').read().decode('utf-8')
+matches = re.findall(r'([0-9\.]+)</span></a></th>\n\s*<td headers="files_date_h" class="opt"><abbr title="(....-..-..)', data)
+releases = [{'version': match[0], 'released': match[1]} for match in matches if match[0].startswith('1.0')]

--- a/utils/fixparts.xml
+++ b/utils/fixparts.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/utils/fixparts" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>FixParts</name>
+  <summary>fixes some common problems on MBR disks</summary>
+  <description>The FixParts utility fixes some common problems on Master Boot Record (MBR) disks.</description>
+  <homepage>http://www.rodsbooks.com/fixparts/</homepage>
+  <category>System</category>
+  <category>Utility</category>
+  <needs-terminal/>
+
+  <package-implementation distributions="Debian" main="/sbin/fixparts" package="gdisk"/>
+  <package-implementation distributions="RPM" main="/usr/sbin/fixparts" package="fixparts"/>
+
+  <group arch="Windows-x86_64" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="fixparts64.exe"/>
+    <implementation id="Windows-x86_64-0.8.7" released="2013-07-09" stability="stable" version="0.8.7">
+      <manifest-digest sha256new="ASDWHDPBHQSUJMJRYW4PD7QQGQZKWKXP62PNP57LFAZOIOFV3F6A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.7/fixparts-binaries/fixparts-windows-0.8.7.zip" size="62942" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-0.8.8" released="2013-10-14" stability="stable" version="0.8.8">
+      <manifest-digest sha256new="ZZIGRZCRZE72KVY2OWYS6NSBW3WTXXCUQSXC53C4QUADQAXPOV5A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.8/fixparts-binaries/fixparts-windows-0.8.8.zip" size="63657" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-0.8.9" released="2014-02-17" stability="stable" version="0.8.9">
+      <manifest-digest sha256new="J3GZK5HI4L5ZOVMJWTB2RBDPH6S337PR4PUJKYON5GSAIYTG5S4A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/fixparts-binaries/fixparts-windows-0.8.9.zip" size="64352" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-0.8.10" released="2014-03-02" stability="stable" version="0.8.10">
+      <manifest-digest sha256new="5QJHYQVS7SVL62BEVULSNABTKEGMPPOG2A4NC7XT5AOI5N4XOAEQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/fixparts-binaries/fixparts-windows-0.8.10.zip" size="515827" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.0" released="2015-03-17" stability="stable" version="1.0.0">
+      <manifest-digest sha256new="YW6PXY3JHAS4ILAREIHND4KRO23QIPWYH7JW3F7YGHQKZ47Q7A7Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/fixparts-binaries/fixparts-windows-1.0.0.zip" size="517134" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.1" released="2015-10-20" stability="stable" version="1.0.1">
+      <manifest-digest sha256new="DWUK4LGZPOHZO55JQPC3IC6I5FMRTCFGAABQ6PGFQSSXY7DAQQDA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/fixparts-binaries/fixparts-windows-1.0.1.zip" size="518563" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.3" released="2017-07-28" stability="stable" version="1.0.3">
+      <manifest-digest sha256new="5HJD37XERUIQSNCVUXMOYAMJQ7Q2B4XVRJ5E3FRH424UXR5BSI2Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/fixparts-binaries/fixparts-windows-1.0.3.zip" size="674139" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.4" released="2018-07-05" stability="stable" version="1.0.4">
+      <manifest-digest sha256new="D5CAUO4QR2YDLWZO57GXRW3PG3UHJLMDQCZI5VLOTYY2K4CW4Y3Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/fixparts-binaries/fixparts-windows-1.0.4.zip" size="685107" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group arch="Windows-i486" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="fixparts32.exe"/>
+    <implementation id="Windows-i486-0.8.7" released="2013-07-09" stability="stable" version="0.8.7">
+      <manifest-digest sha256new="ASDWHDPBHQSUJMJRYW4PD7QQGQZKWKXP62PNP57LFAZOIOFV3F6A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.7/fixparts-binaries/fixparts-windows-0.8.7.zip" size="62942" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-0.8.8" released="2013-10-14" stability="stable" version="0.8.8">
+      <manifest-digest sha256new="ZZIGRZCRZE72KVY2OWYS6NSBW3WTXXCUQSXC53C4QUADQAXPOV5A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.8/fixparts-binaries/fixparts-windows-0.8.8.zip" size="63657" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-0.8.9" released="2014-02-17" stability="stable" version="0.8.9">
+      <manifest-digest sha256new="J3GZK5HI4L5ZOVMJWTB2RBDPH6S337PR4PUJKYON5GSAIYTG5S4A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/fixparts-binaries/fixparts-windows-0.8.9.zip" size="64352" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-0.8.10" released="2014-03-02" stability="stable" version="0.8.10">
+      <manifest-digest sha256new="5QJHYQVS7SVL62BEVULSNABTKEGMPPOG2A4NC7XT5AOI5N4XOAEQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/fixparts-binaries/fixparts-windows-0.8.10.zip" size="515827" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.0" released="2015-03-17" stability="stable" version="1.0.0">
+      <manifest-digest sha256new="YW6PXY3JHAS4ILAREIHND4KRO23QIPWYH7JW3F7YGHQKZ47Q7A7Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/fixparts-binaries/fixparts-windows-1.0.0.zip" size="517134" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.1" released="2015-10-20" stability="stable" version="1.0.1">
+      <manifest-digest sha256new="DWUK4LGZPOHZO55JQPC3IC6I5FMRTCFGAABQ6PGFQSSXY7DAQQDA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/fixparts-binaries/fixparts-windows-1.0.1.zip" size="518563" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.3" released="2017-07-28" stability="stable" version="1.0.3">
+      <manifest-digest sha256new="5HJD37XERUIQSNCVUXMOYAMJQ7Q2B4XVRJ5E3FRH424UXR5BSI2Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/fixparts-binaries/fixparts-windows-1.0.3.zip" size="674139" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.4" released="2018-07-05" stability="stable" version="1.0.4">
+      <manifest-digest sha256new="D5CAUO4QR2YDLWZO57GXRW3PG3UHJLMDQCZI5VLOTYY2K4CW4Y3Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/fixparts-binaries/fixparts-windows-1.0.4.zip" size="685107" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group doc-dir="usr/share/doc/fixparts" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="usr/sbin/fixparts"/>
+    <implementation arch="Linux-x86_64" id="sha1new=373558c7e41119ec3c8cb854d00b12baee67ebc3" released="2014-02-17" stability="stable" version="0.8.9-2">
+      <manifest-digest sha256new="I5ON2TYHVX7UNQRBBBHVQVWRGFHUZGGVKXRSJH4YU3YKEZVYXW6A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/fixparts-binaries/fixparts_0.8.9-2_amd64.deb" size="66808" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=83966a32d8670ced567516e93a44cbaf39c1b876" released="2014-02-17" stability="stable" version="0.8.9-1">
+      <manifest-digest sha256new="A5YPLVVQZ3IZKPSXOL4E42GWBKU3YGLUALT43CEZ4AJNIKDJVL6A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/fixparts-binaries/fixparts_0.8.9-1_i386.deb" size="62430" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=3ddb8561629240d78aab072de209fb3b02b0a726" released="2014-03-02" stability="stable" version="0.8.10-1">
+      <manifest-digest sha256new="TQG7HCIYZEDSLRXLMABTT6MKBDI3FAD5ZL3FBRHPVNZ3AVTGEJ3A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/fixparts-binaries/fixparts_0.8.10-1_amd64.deb" size="67438" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=ce9698a32b6127b07ef3042b808cd89c17ce83ea" released="2014-03-02" stability="stable" version="0.8.10-1">
+      <manifest-digest sha256new="WYKJYJNIYW25I5UX7QAWQCF4Y74PMZPSBBNSDRNH66OC2OGAULMQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/fixparts-binaries/fixparts_0.8.10-1_i386.deb" size="62012" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=be87255a556d139080c9c2d343098801e5dbd571" released="2015-03-17" stability="stable" version="1.0.0-1">
+      <manifest-digest sha256new="SFXAFQMM2RVFLNZ3FDHNPSQEAZFUB5YS675X44LTE6YCWVUXVY7A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/fixparts-binaries/fixparts_1.0.0-1_amd64.deb" size="62808" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=89dbcc91145503d1a622864654e5865f08ab04e9" released="2015-03-17" stability="stable" version="1.0.0-1">
+      <manifest-digest sha256new="QY74W5OXSHMHRIRBZZVMOA3W7DHZYBE7DFQLM4BATCP7BPJ4DJXQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/fixparts-binaries/fixparts_1.0.0-1_i386.deb" size="68134" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=ed75278bc6f1538f83a19ffe7fa7a5c4df597200" released="2015-10-20" stability="stable" version="1.0.1-1">
+      <manifest-digest sha256new="HPF5S2ZQGCXGA5UYLAXF7QMABWLKJT7HXJ6PMT7EGQVFIBKYDRPA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/fixparts-binaries/fixparts_1.0.1-1_amd64.deb" size="64282" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=61112d177b028d49b674c13355c0cd0bc0f4cfcc" released="2015-10-20" stability="stable" version="1.0.1-1">
+      <manifest-digest sha256new="OSNVYTIFFPF5Z6NZNBDSM22LKHPX7DRVCPKYMGYMJYDDNPESA4VA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/fixparts-binaries/fixparts_1.0.1-1_i386.deb" size="64238" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=57cab220d7a09535abe7de032d1d51d06bba225d" released="2017-07-28" stability="stable" version="1.0.3-1">
+      <manifest-digest sha256new="XCFOXY2FEPOVQMXP2CUZADSEISVBAUQFHZUSZ36YQ4BE7QE6MGCA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/fixparts-binaries/fixparts_1.0.3-1_amd64.deb" size="66478" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=eae0e6092115689873294fbec5c2fc833793e8a4" released="2017-07-28" stability="stable" version="1.0.3-1">
+      <manifest-digest sha256new="G2SW5E3HO6HM3CNJL56TLWMHYSR63IQMQY6IIMGOLBKKGZGBA3SQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/fixparts-binaries/fixparts_1.0.3-1_i386.deb" size="67348" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=e098165df0edb90821749bdc3993792a90c586a3" released="2018-07-05" stability="stable" version="1.0.4-1">
+      <manifest-digest sha256new="5RXH4JUMJVCHKBAQOQPRGUZSTIF5YMTGIUL5PRAD5QPZ57HO4HJQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/fixparts-binaries/fixparts_1.0.4-1_amd64.deb" size="67968" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=de3b35521d2b3307b6ad1fed867297d20e4bde45" released="2018-07-05" stability="stable" version="1.0.4-1">
+      <manifest-digest sha256new="ROBNZM7PXY5TOZ6BJ6ZU3KTHY5IZH4TGHDYIM7SW7BLZ22PN7OFQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/fixparts-binaries/fixparts_1.0.4-1_i386.deb" size="70528" type="application/x-deb"/>
+    </implementation>
+  </group>
+
+  <entry-point binary-name="fixparts" command="run"/>
+</interface>

--- a/utils/fixparts.xml.template
+++ b/utils/fixparts.xml.template
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>FixParts</name>
+  <summary>fixes some common problems on MBR disks</summary>
+  <description>The FixParts utility fixes some common problems on Master Boot Record (MBR) disks.</description>
+  <homepage>http://www.rodsbooks.com/fixparts/</homepage>
+  <category>System</category>
+  <category>Utility</category>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/utils/fixparts"/>
+
+  <group arch="Windows-x86_64" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="fixparts64.exe"/>
+    <implementation id="Windows-x86_64-{version}" version="{version}" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/fixparts-binaries/fixparts-windows-{version}.zip" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group arch="Windows-i486" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="fixparts32.exe"/>
+    <implementation id="Windows-i486-{version}" version="{version}" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/fixparts-binaries/fixparts-windows-{version}.zip" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group doc-dir="usr/share/doc/fixparts" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="usr/sbin/fixparts"/>
+    <implementation arch="Linux-x86_64" version="{version}-1" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/fixparts-binaries/fixparts_{version}-1_amd64.deb" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" version="{version}-1" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/fixparts-binaries/fixparts_{version}-1_i386.deb" type="application/x-deb"/>
+    </implementation>
+  </group>
+</interface>

--- a/utils/gdisk.watch.py
+++ b/utils/gdisk.watch.py
@@ -1,0 +1,6 @@
+from urllib import request
+import re
+
+data = request.urlopen('https://sourceforge.net/projects/gptfdisk/files/gptfdisk/').read().decode('utf-8')
+matches = re.findall(r'([0-9\.]+)</span></a></th>\n\s*<td headers="files_date_h" class="opt"><abbr title="(....-..-..)', data)
+releases = [{'version': match[0], 'released': match[1]} for match in matches if match[0].startswith('1.0')]

--- a/utils/gdisk.xml
+++ b/utils/gdisk.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/utils/gdisk" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>GPT fdisk</name>
+  <summary>disk partitioning tool for modifying GPT disks</summary>
+  <description>GPT fdisk is a disk partitioning tool loosely modeled on Linux fdisk, but used for modifying GUID Partition Table (GPT) disks.</description>
+  <homepage>http://www.rodsbooks.com/gdisk/</homepage>
+  <category>System</category>
+  <category>Utility</category>
+  <needs-terminal/>
+
+  <package-implementation distributions="Debian" main="/sbin/gdisk" package="gdisk"/>
+  <package-implementation distributions="RPM" main="/usr/sbin/gdisk" package="gdisk"/>
+
+  <group arch="Windows-x86_64" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="gdisk64.exe"/>
+    <implementation id="Windows-x86_64-0.8.7" released="2013-07-09" stability="stable" version="0.8.7">
+      <manifest-digest sha256new="DAA7OLWNT6O7XNCESWLTGXAW4MDWYDR7IJLQQ2U6ZZ2AOEP2GVPQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.7/gdisk-binaries/gdisk-windows-0.8.7.zip" size="108378" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-0.8.8" released="2013-10-14" stability="stable" version="0.8.8">
+      <manifest-digest sha256new="XPFOK763JS7BDITGDLY2JBC6PYMIZHG2O5SFOVZADPUPSAEQGPFQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.8/gdisk-binaries/gdisk-windows-0.8.8.zip" size="109626" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-0.8.9" released="2014-02-17" stability="stable" version="0.8.9">
+      <manifest-digest sha256new="5X264JKLRNOEFRRDZDZZOZOS5T4TJ676Z2W22VMFCW4V65XDGP2Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/gdisk-binaries/gdisk-windows-0.8.9.zip" size="111152" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-0.8.10" released="2014-03-02" stability="stable" version="0.8.10">
+      <manifest-digest sha256new="P3ECKFFH3OER2EGKLPCK5RD4V6MSLYTDXQFHT7DLFOMATXORM2KA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/gdisk-binaries/gdisk-windows-0.8.10.zip" size="628225" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.0" released="2015-03-17" stability="stable" version="1.0.0">
+      <manifest-digest sha256new="UDVCGXGVS36DBENNI6ESPQNYERNFWPLM4ESUHUVJCJRS3LGEXINA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/gdisk-binaries/gdisk-windows-1.0.0.zip" size="630058" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.1" released="2015-10-20" stability="stable" version="1.0.1">
+      <manifest-digest sha256new="B55HD5CN5BUDKSC7TTZCBWVCUJL7S5HIPOURRP7LRLVOQ634CTJQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/gdisk-binaries/gdisk-windows-1.0.1.zip" size="631692" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.3" released="2017-07-28" stability="stable" version="1.0.3">
+      <manifest-digest sha256new="HM5RWDCKV7DFFEEU6463LRL3XQMNN5LEZBHGAVW5CPDJGQPHBYDA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/gdisk-binaries/gdisk-windows-1.0.3.zip" size="789337" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-x86_64-1.0.4" released="2018-07-05" stability="stable" version="1.0.4">
+      <manifest-digest sha256new="IETAAX6JRGD3MRK3PQLMP3XCQPRHR222Q2GG2RGLVQNZOGFFEPGQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/gdisk-binaries/gdisk-windows-1.0.4.zip" size="808043" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group arch="Windows-i486" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="gdisk32.exe"/>
+    <implementation id="Windows-i486-0.8.7" released="2013-07-09" stability="stable" version="0.8.7">
+      <manifest-digest sha256new="DAA7OLWNT6O7XNCESWLTGXAW4MDWYDR7IJLQQ2U6ZZ2AOEP2GVPQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.7/gdisk-binaries/gdisk-windows-0.8.7.zip" size="108378" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-0.8.8" released="2013-10-14" stability="stable" version="0.8.8">
+      <manifest-digest sha256new="XPFOK763JS7BDITGDLY2JBC6PYMIZHG2O5SFOVZADPUPSAEQGPFQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.8/gdisk-binaries/gdisk-windows-0.8.8.zip" size="109626" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-0.8.9" released="2014-02-17" stability="stable" version="0.8.9">
+      <manifest-digest sha256new="5X264JKLRNOEFRRDZDZZOZOS5T4TJ676Z2W22VMFCW4V65XDGP2Q"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/gdisk-binaries/gdisk-windows-0.8.9.zip" size="111152" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-0.8.10" released="2014-03-02" stability="stable" version="0.8.10">
+      <manifest-digest sha256new="P3ECKFFH3OER2EGKLPCK5RD4V6MSLYTDXQFHT7DLFOMATXORM2KA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/gdisk-binaries/gdisk-windows-0.8.10.zip" size="628225" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.0" released="2015-03-17" stability="stable" version="1.0.0">
+      <manifest-digest sha256new="UDVCGXGVS36DBENNI6ESPQNYERNFWPLM4ESUHUVJCJRS3LGEXINA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/gdisk-binaries/gdisk-windows-1.0.0.zip" size="630058" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.1" released="2015-10-20" stability="stable" version="1.0.1">
+      <manifest-digest sha256new="B55HD5CN5BUDKSC7TTZCBWVCUJL7S5HIPOURRP7LRLVOQ634CTJQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/gdisk-binaries/gdisk-windows-1.0.1.zip" size="631692" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.3" released="2017-07-28" stability="stable" version="1.0.3">
+      <manifest-digest sha256new="HM5RWDCKV7DFFEEU6463LRL3XQMNN5LEZBHGAVW5CPDJGQPHBYDA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/gdisk-binaries/gdisk-windows-1.0.3.zip" size="789337" type="application/zip"/>
+    </implementation>
+    <implementation id="Windows-i486-1.0.4" released="2018-07-05" stability="stable" version="1.0.4">
+      <manifest-digest sha256new="IETAAX6JRGD3MRK3PQLMP3XCQPRHR222Q2GG2RGLVQNZOGFFEPGQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/gdisk-binaries/gdisk-windows-1.0.4.zip" size="808043" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group doc-dir="usr/share/doc/gdisk" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="usr/sbin/gdisk"/>
+    <command name="sgdisk" path="usr/sbin/sgdisk"/>
+    <command name="cgdisk" path="usr/sbin/cgdisk"/>
+    <implementation arch="Linux-x86_64" id="sha1new=34f4282d39786353e4b02f9be264110852278b96" released="2014-02-17" stability="stable" version="0.8.9-2">
+      <manifest-digest sha256new="IML4KMBX55VFHGTVUXLGOE5C2GIUE2ROXAQ6FSMXXKGUDFJ3QNLQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/gdisk-binaries/gdisk_0.8.9-2_amd64.deb" size="291348" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=fae69b80266944bf8780eb8aaa88b5487d9f0a48" released="2014-02-17" stability="stable" version="0.8.9-1">
+      <manifest-digest sha256new="UPO7BGFQMMO67IBQSPVPMXU6MNDLH4UNBXDNC6UKTHXTJMV6GEYA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.9/gdisk-binaries/gdisk_0.8.9-1_i386.deb" size="165564" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=6e54351ef5e0a27ab8618e22ed162822f31bedf9" released="2014-03-02" stability="stable" version="0.8.10-1">
+      <manifest-digest sha256new="FNS72D7C3BRH32OZHFZ3K3YJCCDIST45AJZHFPB7XVJYBPRY745A"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/gdisk-binaries/gdisk_0.8.10-1_amd64.deb" size="292596" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=6c74d444c67d0077162876c0f4ea2e5a82464263" released="2014-03-02" stability="stable" version="0.8.10-1">
+      <manifest-digest sha256new="5324SO5RI5LELWZ7SI3TT6TSTDEVDSLWJBVLIHCS2CEDXHRITECQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/0.8.10/gdisk-binaries/gdisk_0.8.10-1_i386.deb" size="166036" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=c0bc0047a9e619dad05a6211eae6db87aaadcddc" released="2015-03-17" stability="stable" version="1.0.0-1">
+      <manifest-digest sha256new="GQ4AX2IOXC2YL6LFF3DHEKV4YO7XY25DKVFYUKBRDCXA5E5WWZDA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/gdisk-binaries/gdisk_1.0.0-1_amd64.deb" size="167050" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=6aa5614914618ec49d5eaa5ea7be264c2421ffe1" released="2015-03-17" stability="stable" version="1.0.0-1">
+      <manifest-digest sha256new="6QLTUQRQJ4QLRISP3XHRAMFNHPPZOSYMSS3DBZSCGJDYESLY3SUQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.0/gdisk-binaries/gdisk_1.0.0-1_i386.deb" size="296630" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=0d4536e2c9054d110aa0db629a83c2b0c80efc1e" released="2015-10-20" stability="stable" version="1.0.1-1">
+      <manifest-digest sha256new="DSTMZ6F6GAT2ZKLOWPST7ZLRKIJKDYUAASHQ75FUGBFMDMMP2RAQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/gdisk-binaries/gdisk_1.0.1-1_amd64.deb" size="168798" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=8c4d2ed1dc874501c2cfad40fd8358ac5f5969f5" released="2015-10-20" stability="stable" version="1.0.1-1">
+      <manifest-digest sha256new="HENSIARGEWNIXE4INBBGFDIYVHHW2IUG4SAOWXRGJCUCL6J5K7XA"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/gdisk-binaries/gdisk_1.0.1-1_i386.deb" size="168756" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=66a1234d5118695dfaf523bb26b5971f4808cd29" released="2017-07-28" stability="stable" version="1.0.3-1">
+      <manifest-digest sha256new="7SUKINMFHG3X2FZQ7NJRNS3POQV6ABBLKVIOBBLKINS35S2LOEUQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/gdisk-binaries/gdisk_1.0.3-1_amd64.deb" size="178876" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=e4d11be30a69077481c85dc709ae2d8b42c7b4ad" released="2017-07-28" stability="stable" version="1.0.3-1">
+      <manifest-digest sha256new="C2IXVQMXHT5EOVMTRAGJ3234Y6723DDG24CPANLZPXDC63FR56FQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.3/gdisk-binaries/gdisk_1.0.3-1_i386.deb" size="178110" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=83b74b8a21e30654c1b9c296706a34aeb211f5c1" released="2018-07-05" stability="stable" version="1.0.4-1">
+      <manifest-digest sha256new="SFMRBZFBF7VJWC7WG46ZBE7PHHZOERNGZ7LMTRGQC4NMENQLVPPQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/gdisk-binaries/gdisk_1.0.4-1_amd64.deb" size="183664" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=e4638c3af8ae8edc72cfbc38cde3725e82b4e2fe" released="2018-07-05" stability="stable" version="1.0.4-1">
+      <manifest-digest sha256new="U3WY3LMAHJULO34IEK4WKZP3WCGFEARULYCTQQ3FJ77WO55FQOGQ"/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.4/gdisk-binaries/gdisk_1.0.4-1_i386.deb" size="192060" type="application/x-deb"/>
+    </implementation>
+  </group>
+
+  <entry-point binary-name="gdisk" command="run"/>
+</interface>

--- a/utils/gdisk.xml.template
+++ b/utils/gdisk.xml.template
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>GPT fdisk</name>
+  <summary>disk partitioning tool for modifying GPT disks</summary>
+  <description>GPT fdisk is a disk partitioning tool loosely modeled on Linux fdisk, but used for modifying GUID Partition Table (GPT) disks.</description>
+  <homepage>http://www.rodsbooks.com/gdisk/</homepage>
+  <category>System</category>
+  <category>Utility</category>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/utils/gdisk"/>
+
+  <group arch="Windows-x86_64" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="gdisk64.exe"/>
+    <implementation id="Windows-x86_64-{version}" version="{version}" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/gdisk-binaries/gdisk-windows-{version}.zip" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group arch="Windows-i486" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="gdisk32.exe"/>
+    <implementation id="Windows-i486-{version}" version="{version}" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/gdisk-binaries/gdisk-windows-{version}.zip" type="application/zip"/>
+    </implementation>
+  </group>
+
+  <group doc-dir="usr/share/doc/gdisk" license="GPL v2 (GNU General Public License)">
+    <command name="run" path="usr/sbin/gdisk"/>
+    <command name="sgdisk" path="usr/sbin/sgdisk"/>
+    <command name="cgdisk" path="usr/sbin/cgdisk"/>
+    <implementation arch="Linux-x86_64" version="{version}-1" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/gdisk-binaries/gdisk_{version}-1_amd64.deb" type="application/x-deb"/>
+    </implementation>
+    <implementation arch="Linux-i386" version="{version}-1" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="http://sourceforge.net/projects/gptfdisk/files/gptfdisk/{version}/gdisk-binaries/gdisk_{version}-1_i386.deb" type="application/x-deb"/>
+    </implementation>
+  </group>
+</interface>


### PR DESCRIPTION
This adds feeds for the following utilities:
- Atom
- Visual Studio Code
- GPT fdisk
- FixParts
- Nmap
- GitVersion

New `editors/index.html`:
```html
<!DOCTYPE html>
<html>
  <head>
    <title>repo.roscidus.com: Editors</title>
  </head>
  <body>
    <h1>repo.roscidus.com: Editors</h1>

    <h2>Available feeds</h2>

    <ul>
      <li><a href='atom'>Atom</a> - the hackable text editor</li>
      <li><a href='vs-code'>Visual Studio Code</a> - lightweight but powerful source code editor</li>
    </ul>
  </body>
</html>
```

Additions for `utils/index.html`:
```html
      <li><a href='gdisk'>GPT fdisk</a> (gdisk) - disk partitioning tool for modifying GPT disks</li>
      <li><a href='fixparts'>FixParts</a> - fixes some common problems on MBR disks</li>
```


Addition for `security/index.html`:
```html
	    <dt><a href='nmap'>NMap</a></dt><dd>utility for network discovery and security auditing</dd>
```

Addition for `devel/index.html`:
```html
	    <dt><a href='gitversion'>GitVersion</a></dt><dd>versioning when using git, solved</dd>
```