### PR TITLE
Fixed libicu Debian packages

### DIFF
--- a/lib/icu.xml
+++ b/lib/icu.xml
@@ -3,5 +3,6 @@
   <name>libicu</name>
   <summary>library that provides robust and full-featured Unicode and locale support</summary>
   <package-implementation distributions="RPM Arch" package="libicu"/>
-  <package-implementation distributions="Debian" package="libicu57 libicu60"/>
+  <package-implementation distributions="Debian" package="libicu57"/>
+  <package-implementation distributions="Debian" package="libicu60"/>
 </interface>


### PR DESCRIPTION
@talex5 Could you merge this soon-ish? This breaks running http://repo.roscidus.com/devel/gitversion on Debian. Sorry, for dropping the ball on this. :(