### PR TITLE
Added GLib dependency to python-gobject

### DIFF
--- a/lib/glib.xml
+++ b/lib/glib.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/lib/glib" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>GLib</name>
+  <summary>low-level system libraries written in C</summary>
+  <description>GLib provides the core application building blocks for libraries and applications written in C. It provides the core object system used in GNOME, the main loop implementation, and a large set of utility functions for strings and common data structures.</description>
+  <homepage>https://wiki.gnome.org/Projects/GLib</homepage>
+
+  <!-- Windows binaries of GLib are available as part of GTK releases -->
+  <feed arch="Windows-*" src="http://repo.roscidus.com/lib/gtk"/>
+
+  <package-implementation package="glib"/>
+  <package-implementation package="libglib"/>
+  <package-implementation package="libglib2"/>
+  <package-implementation package="libglib2.0"/>
+  <package-implementation package="libglib2.0-0"/>
+  <package-implementation package="libglib-2.0"/>
+  <package-implementation package="libglib3"/>
+  <package-implementation package="libglib3.0"/>
+  <package-implementation package="libglib3.0-0"/>
+  <package-implementation package="libglib-3.0"/>
+</interface>

--- a/python/python-gobject.xml
+++ b/python/python-gobject.xml
@@ -44,6 +44,7 @@ the core library used to build GTK+ and GNOME.
     <restricts interface="http://repo.roscidus.com/python/python">
       <version before="2.8" not-before="2.7"/>
     </restricts>
+    <requires interface="http://repo.roscidus.com/lib/glib"/>
     <environment name="PYTHONPATH" insert="." />
     <environment name="PYTHONPATH" insert="gtk-2.0" />
 


### PR DESCRIPTION
This should fix `ImportError: No module named gobject` on Windows.

New line for `lib/index.html`:
```html
        <dt><a href="glib">GLib</a><dd>low-level system libraries written in C</dd>
```