### PR TITLE
PyGTK

### DIFF
--- a/lib/gtk.xml
+++ b/lib/gtk.xml
@@ -38,10 +38,23 @@
       <manifest-digest sha256new="PER46UXB3PS3V545GUJYL4K4W257LNYOTOCYEMT2IZVOMRIZI6UQ"/>
       <archive extract="Gtk" href="https://downloads.sourceforge.net/project/pidgin/GTK%2B%20for%20Windows/2.16.6.3/gtk-runtime-2.16.6.3.zip" size="12363051" type="application/zip"/>
     </implementation>
+
     <implementation id="sha1new=f96db6b92ed3f41fc9a225d8e4eb343e0d859ecc" released="2012-02-08" stability="stable" version="2.24.10">
       <manifest-digest sha256new="V36BMVEDEIGK2IR5KESEYLQUQZ3SKXWUIEDJTBWO252O56RGUOVA"/>
       <archive href="http://ftp.gnome.org/pub/GNOME/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip" size="24700662" type="application/zip"/>
     </implementation>
   </group>
 
+  <group license="GPL v2 (GNU General Public License)">
+    <environment name="." insert="bin" />
+
+    <implementation arch="Windows-x86_64" version="3.18.9" stability="stable" id="sha1new=d7336dffb401b6eac10a871dc978790fecf72e97">
+      <manifest-digest sha256new="LABYAMAZ56OMB2QCI7IAPQGS6PV3DUGYV4DBXNMGJO5VQD7XDJKQ" />
+      <archive href="libgtk-3.18.9-vc10-win64.zip" size="2378757" type="application/zip" />
+    </implementation>
+    <implementation arch="Windows-i486" version="3.18.9" stability="stable" id="sha1new=1c8ae1a5a777c3dcb0d93ace634b9e6419cf36ca">
+      <manifest-digest sha256new="7IZKAKKANLK4MUML4QENTPSDKC3T64RPDN7C6E36NZ5DAMLN2SOA" />
+      <archive href="libgtk-3.18.9-vc10-win32.zip" size="2278497" type="application/zip" />
+    </implementation>
+  </group>
 </interface>

--- a/python/python-gobject.xml
+++ b/python/python-gobject.xml
@@ -59,4 +59,19 @@ the core library used to build GTK+ and GNOME.
       <archive href="pygobject-2.28.6-cp27-none-win32.whl" size="511973" type="application/zip" />
     </implementation>
   </group>
+
+  <group license="LGPL (GNU Lesser General Public License)">
+    <restricts interface="http://repo.roscidus.com/python/python" version="3.4..!3.5" />
+    <requires interface="http://repo.roscidus.com/lib/gtk" version="3.18..!4" />
+    <environment name="PYTHONPATH" insert="." />
+
+    <implementation arch="Windows-x86_64" version="3.24.1" stability="stable" id="sha1new=4e13aab34b0b9e821f865ac2727527d21762db4b">
+      <manifest-digest sha256new="PQXAXJZSCXW3TXMF3VLMTHVHJLCG6X75H3JW72D5NDX2YMWVA2KQ" />
+      <archive href="pygobject-3.24.1-py3.4-win64.zip" size="306152" type="application/zip" />
+    </implementation>
+    <implementation arch="Windows-i486" version="3.24.1" stability="stable" id="sha1new=30912d6c8006758785ce97160bb6223752fb9a9f">
+      <manifest-digest sha256new="AFIIFWYRGY7HNFKSQUGGLITO62J33XIQ4RRBCNFBBU3YOIFYYNXQ" />
+      <archive href="pygobject-3.24.1-py3.4-win32.zip" size="294434" type="application/zip" />
+    </implementation>
+  </group>
 </interface>


### PR DESCRIPTION
This PR adds PyGTK 2 libs for Python 2.7 (32-bit and 64-bit).
The binaries are from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pygtk, as suggested by @pmiess on the mailing list.

The following files need to be downloaded and placed in `incoming/` for `0repo` to work:
- [pygobject-2.28.6-cp27-none-win_amd64.whl](https://0install.de/files/temp/pygobject-2.28.6-cp27-none-win_amd64.whl)
- [pygobject-2.28.6-cp27-none-win32.whl](https://0install.de/files/temp/pygobject-2.28.6-cp27-none-win32.whl)
- [pycairo_gtk-1.10.0-cp27-none-win_amd64.whl](https://0install.de/files/temp/pycairo_gtk-1.10.0-cp27-none-win_amd64.whl)
- [pycairo_gtk-1.10.0-cp27-none-win32.whl](https://0install.de/files/temp/pycairo_gtk-1.10.0-cp27-none-win32.whl)
- [pygtk-2.22.0-cp27-none-win_amd64.whl](https://0install.de/files/temp/pygtk-2.22.0-cp27-none-win_amd64.whl)
- [pygtk-2.22.0-cp27-none-win32.whl](https://0install.de/files/temp/pygtk-2.22.0-cp27-none-win32.whl)

These are unmodified copies of the files provided by the page above. I did not deep-link to the original archives because the site says "Please only download files manually as needed." and uses JavaScript to obfuscate the download URIs.

This PR also adds python-gobject 3 for Python 3.4 (32-bit and 64-bit).
The binaries are from https://sourceforge.net/projects/pygobjectwin32/.

The following files need to be downloaded and placed in `incoming/` for `0repo` to work:
- [libgtk-3.18.9-vc10-win32.7z](https://0install.de/files/temp/libgtk-3.18.9-vc10-win32.7z)
- [libgtk-3.18.9-vc10-win64.7z](https://0install.de/files/temp/libgtk-3.18.9-vc10-win64.7z)
- [pygobject-3.24.1-py3.4-win32.7z](https://0install.de/files/temp/pygobject-3.24.1-py3.4-win32.7z)
- [pygobject-3.24.1-py3.4-win64.7z](https://0install.de/files/temp/pygobject-3.24.1-py3.4-win64.7z)

These are unmodified archives extracted from the setup EXE provided by the page above.