### PR TITLE
Updated GnuPG for Windows

### DIFF
--- a/security/gnupg.xml
+++ b/security/gnupg.xml
@@ -61,6 +61,10 @@ because it uses IDEA (which is patented worldwide).</description>
       <manifest-digest sha1new="8baef90a82cbf543e5d3d791fda3d46157f0ca9d" sha256="d76b93905853e6e3aad9ac7d0f64b6d177ed4149c5cc45a2d8ed553c7e10b395" sha256new="25VZHECYKPTOHKWZVR6Q6ZFW2F362QKJYXGELIWY5VKTY7QQWOKQ"/>
       <archive href="gnupg-w32cli-1.4.22.zip" size="2840518" type="application/zip"/>
     </implementation>
+    <implementation id="sha1new=5b1e973aee2f6be3fa4af2a4ffc6d37342a334aa" released="2018-06-11" stability="stable" version="1.4.23">
+      <manifest-digest sha256new="PEQH4OUEHZ376SFT4IB3D2LI2KIYGHVPKU55GBLRU7NZEPMIDXTA"/>
+      <archive href="gnupg-w32cli-1.4.23.zip" size="2835894" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="gpg" command="run"/>


### PR DESCRIPTION
[gnupg-w32cli-1.4.23.zip](https://github.com/0install/repo.roscidus.com/files/2840664/gnupg-w32cli-1.4.23.zip) needs to be added to 0repo's `incoming` directory.

I created this file by downloading https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32cli-1.4.23.exe, extracting the installer's content and repacking it as a ZIP archive.