### PR TITLE
Automatic updates

### DIFF
--- a/dotnet/core-sdk.xml
+++ b/dotnet/core-sdk.xml
@@ -235,6 +235,14 @@
       <manifest-digest sha256new="XDXNQMD7O5VSYPWOSLELMAIYWFFLFNXULX5MXRVR7CNWN2W3SATA"/>
       <archive href="https://download.visualstudio.microsoft.com/download/pr/59e18010-8e57-4073-add2-d2b5cfbc5e58/8fa6831c7be0800889324640e29476f4/dotnet-sdk-2.2.104-win-x86.zip" size="153915161" type="application/zip"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=f672a419e40ea0df1713f4af5f46c8bf49102722" released="2019-03-12" stability="stable" version="2.2.105">
+      <manifest-digest sha256new="4RPO32HBZS6SRZUYPVUIH3QJALZY43AGUZ32CXP2E75V5AMHK2HA"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/5fda1224-7b3b-4aac-9516-47e2e38f78cb/ac7ad8eab35268b234c386b53f354161/dotnet-sdk-2.2.105-win-x64.zip" size="163400422" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=b3ae7ee30827d98ba850260f2596308c0317c8f8" released="2019-03-12" stability="stable" version="2.2.105">
+      <manifest-digest sha256new="OVGX7MKRBRULHLBK2AG7S3VMN26YIQWQXDN5JER7JOLJHM4PTMPQ"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/6952677d-f0de-46ed-80ca-209e997ca909/d578118f63c0be3fd9533376adaf314e/dotnet-sdk-2.2.105-win-x86.zip" size="154275798" type="application/zip"/>
+    </implementation>
   </group>
 
   <group arch="Linux-x86_64" license="MIT License" main="dotnet">
@@ -338,6 +346,10 @@
       <manifest-digest sha256new="3XU7DZMZV5XU23GYJEWV5LUK35VRG4TFN3CUOXWU3VX45KTB5GGQ"/>
       <archive href="https://download.visualstudio.microsoft.com/download/pr/69937b49-a877-4ced-81e6-286620b390ab/8ab938cf6f5e83b2221630354160ef21/dotnet-sdk-2.2.104-linux-x64.tar.gz" size="165513507" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation id="sha1new=73d64f25827366ef38ad00155fe509f6f8539880" released="2019-03-12" stability="stable" version="2.2.105">
+      <manifest-digest sha256new="UJPPZQBLXMODY52FOUBSIQQOVZP5PPRBYI2IDJDQRWCLEVSXY6DA"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/7d8f3f4c-9a90-42c5-956f-45f673384d3f/14d686d853a964025f5c54db237ff6ef/dotnet-sdk-2.2.105-linux-x64.tar.gz" size="165834085" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
 
   <group arch="MacOSX-x86_64" license="MIT License">
@@ -398,6 +410,10 @@
     <implementation id="sha1new=adec723bf8db6dc54b3dfcd32903513a06fe58b4" released="2019-02-12" stability="stable" version="2.2.104">
       <manifest-digest sha256new="WLXUK4ZKP6ESGLUIJANNG2C3JGLGGBQGHFT4ZVF6VXRMFEORT46A"/>
       <archive href="https://download.visualstudio.microsoft.com/download/pr/7b61ec42-34d4-443a-9472-10db3b600b00/331956fdc0884ec01aaa5aa44360fce2/dotnet-sdk-2.2.104-osx-x64.tar.gz" size="165177609" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation id="sha1new=21935815c30bd54e5350ba3202e7942bb655fb5e" released="2019-03-12" stability="stable" version="2.2.105">
+      <manifest-digest sha256new="X26T2TPAEN3O5YF2Z6UDXMJ4BPYJVXVIXPTTUCSJIYWFTKQ6V74Q"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/47709d55-450a-4828-9e3a-de65aef7c2f2/f512dd0abf6989ce1800d4fd40a745d7/dotnet-sdk-2.2.105-osx-x64.tar.gz" size="165508678" type="application/x-compressed-tar"/>
     </implementation>
   </group>
 

--- a/dotnet/core.xml
+++ b/dotnet/core.xml
@@ -216,6 +216,14 @@
       <manifest-digest sha256new="56AJPS3PYJ74KZWIKZY4JMXROBHHVFVVNPOTV5OW2SZRTBKF47BQ"/>
       <archive href="https://download.visualstudio.microsoft.com/download/pr/97b777ee-6b4e-4d26-9f73-6b33a99e0f67/93458d5a38d673757768eed2f6cec926/dotnet-runtime-2.2.2-win-x86.zip" size="27073849" type="application/zip"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=519d5408d047a59621f7edc2e037e6813189884b" released="2019-03-12" stability="stable" version="2.2.3">
+      <manifest-digest sha256new="B2VH5DSNDOS7VAURWJLHUUWUFEGD5XFUO2R6LJS5XJHN2EA6EMJQ"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/25d53223-179f-46db-b99d-5d433c93a021/dd1f391be09111440b3afe38d22bc15d/dotnet-runtime-2.2.3-win-x64.zip" size="29897326" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=45a06184b226c68ab1e866cdbe6daeeae50a7465" released="2019-03-12" stability="stable" version="2.2.3">
+      <manifest-digest sha256new="UMKSLDD2X7B2V6KOLOT7U5RIWF4RTT4ZLXM5K4IDCN32YFAXKS4Q"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/0281cdac-cfb3-442c-bdfb-abe1b8010bf1/fbbcb7fa128f2bffdec3de28d17e53f4/dotnet-runtime-2.2.3-win-x86.zip" size="27089531" type="application/zip"/>
+    </implementation>
   </group>
 
   <group arch="Linux-x86_64" license="MIT License">
@@ -293,6 +301,10 @@
       <manifest-digest sha256new="XW7PRF3MTFFXQKRLZPDGRKY5DMRUMEZLQWULK7ZXGAVT2ZRJOSAQ"/>
       <archive href="https://download.visualstudio.microsoft.com/download/pr/97b97652-4f74-4866-b708-2e9b41064459/7c722daf1a80a89aa8c3dec9103c24fc/dotnet-runtime-2.2.2-linux-x64.tar.gz" size="28769775" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation id="sha1new=88adecd54d43e4a4e8df370a26bc983fc7dc4f6c" released="2019-03-12" stability="stable" version="2.2.3">
+      <manifest-digest sha256new="UI4BF6F43Z5PNGTLTYNMQ2NLY5RF3BB7ZJCJK53GF3ICZYQ3CONQ"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/28271651-a8f6-41d6-9144-2d53f6c4aac4/bb29124818f370cd08c5c8cc8f8816bf/dotnet-runtime-2.2.3-linux-x64.tar.gz" size="28764477" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
 
   <group arch="MacOSX-x86_64" license="MIT License">
@@ -337,6 +349,10 @@
     <implementation id="sha1new=dc28a6b65f32304f17b93a3ed14e8cf17c9e9d05" released="2019-02-12" stability="stable" version="2.2.2">
       <manifest-digest sha256new="DFDWXMO5XKH2IOHZBPHKCJ254KHGT65XXQVYQGVCG55N2WJMWQNA"/>
       <archive href="https://download.visualstudio.microsoft.com/download/pr/d1f0dfb3-b6bd-42ae-895f-f149bf1d90ca/9b1fb91a9692fc31d6fc83e97caba4cd/dotnet-runtime-2.2.2-osx-x64.tar.gz" size="27579415" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation id="sha1new=e91f5e9d109a6c63771f743c8dc0bf552cf310de" released="2019-03-12" stability="stable" version="2.2.3">
+      <manifest-digest sha256new="4MEYT2BD76JYC3YNZLY4G6ZGVGTCGKKP4MFXSKFLPZZ3MXKPWCKQ"/>
+      <archive href="https://download.visualstudio.microsoft.com/download/pr/17706c0b-9b95-48cf-a305-00e33308fee5/25a080bf4f213bb12ba2dbdd313ac666/dotnet-runtime-2.2.3-osx-x64.tar.gz" size="27598259" type="application/x-compressed-tar"/>
     </implementation>
   </group>
 

--- a/dotnet/docfx.xml
+++ b/dotnet/docfx.xml
@@ -181,6 +181,10 @@
       <manifest-digest sha256new="ENS7IEZB3YZSS7JIIBYIANS5R2FXUJFXMVMMSJEAJIGHNMFE7VSA"/>
       <archive href="https://github.com/dotnet/docfx/releases/download/v2.40.11/docfx.zip" size="22038314" type="application/zip"/>
     </implementation>
+    <implementation id="sha1new=a69b4cedf7bd3d705bde3625c7dbb05045a00312" released="2019-03-11" stability="stable" version="2.40.12">
+      <manifest-digest sha256new="6LACJ73EZDQDZYNYC7PQW65XKOR27LVCHTQ2LNQ5ENIRZCVADJTQ"/>
+      <archive href="https://github.com/dotnet/docfx/releases/download/v2.40.12/docfx.zip" size="22057327" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="docfx" command="run"/>

--- a/dotnet/nuget.xml
+++ b/dotnet/nuget.xml
@@ -90,6 +90,50 @@
       <manifest-digest sha256new="7LM3DLMRFAX6SLBSBBGFVIYTEA34MPF7NZPJQQQGU2CD2DEQDWMA"/>
       <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v5.0.0-preview4/nuget.exe" size="5685840"/>
     </implementation>
+    <implementation id="sha1new=1f55a3bf9904d5562dda87ad40062d78f6d752ea" released="2019-03-12" stability="stable" version="4.3.1">
+      <manifest-digest sha256new="IADVVFV67W3UON3ZGX32NHJRJNQVK46EE7JRO2Y3SJX6YOCFGOEA"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.3.1/nuget.exe" size="5005392"/>
+    </implementation>
+    <implementation id="sha1new=b97abb0cbec5d39fb72f3c39f0cead85fc657496" released="2019-03-12" stability="stable" version="4.4.2">
+      <manifest-digest sha256new="OHXH4YGHRRAGXBVUOHWDGBPTJB6WIMZGHUHTN3MIEBXVOZY5NFYA"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.4.2/nuget.exe" size="5058336"/>
+    </implementation>
+    <implementation id="sha1new=ab9b850f209c125b0e48037477b8426ce973e6ef" released="2019-03-12" stability="stable" version="4.5.2">
+      <manifest-digest sha256new="YNFHOYF4YFK4MWPUK5EILVH5QPKN7ZNPELHA4MHHIHLUQXTCCJVA"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.5.2/nuget.exe" size="5066320"/>
+    </implementation>
+    <implementation id="sha1new=3f5c255261e57b68f73b88f382cc42526f88e70d" released="2019-03-12" stability="stable" version="4.6.3">
+      <manifest-digest sha256new="XOLCYA6OO7QEVTSWLRFZC3MGJNSTF4O5QDEOLB6L3KNJYQRK5ZEQ"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.6.3/nuget.exe" size="5336360"/>
+    </implementation>
+    <implementation id="sha1new=8d1887e4b7f6572c90f67f7fdba1332456300ecc" released="2019-03-12" stability="stable" version="4.7.2">
+      <manifest-digest sha256new="JCGA2QWW7BOWR3T3VIGIUHSG6KXDCM6ONTYYX37CNNXZTJM5EUPQ"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.7.2/nuget.exe" size="5431888"/>
+    </implementation>
+    <implementation id="sha1new=c2dedb427d19b98b10ba56f5bf7e55bda7ab4007" released="2019-03-12" stability="stable" version="4.8.2">
+      <manifest-digest sha256new="6CCUAV6ACJKSIO3LPEDFESAUVTIWL5FDWOMOPHJCFVV5DEDDG73A"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.8.2/nuget.exe" size="5491008"/>
+    </implementation>
+    <implementation id="sha1new=106c59b1418c38c0a84a6886dec7f9955a8da50f" released="2019-03-12" stability="stable" version="4.9.4">
+      <manifest-digest sha256new="KAZ2FUCWTYLE5H4ETTBYKKUFP35DGGFS474HGDX7MWIXC3UJG4CQ"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.9.4/nuget.exe" size="5690456"/>
+    </implementation>
+    <implementation id="sha1new=9633999be717c181add1cf2111d57c8af93ff2c4" released="2019-03-15" stability="stable" version="4.4.3">
+      <manifest-digest sha256new="DQYUWH4JSK7FECDRPR65WTAMC7X5FK5NQH75NRMRMRCFY6ADTN2Q"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.4.3/nuget.exe" size="5060928"/>
+    </implementation>
+    <implementation id="sha1new=f2e35220daa5792ce0423863b5e207985bdcd2c2" released="2019-03-15" stability="stable" version="4.5.3">
+      <manifest-digest sha256new="YYM7GPZSJIKF34VMCA45WSZTE5S57GKVT7JEE6SEA23GOVBTO7DA"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.5.3/nuget.exe" size="5069096"/>
+    </implementation>
+    <implementation id="sha1new=6f99b25139983402e6130d09a1e8269ac802d73e" released="2019-03-15" stability="stable" version="4.6.4">
+      <manifest-digest sha256new="F6E3ZRDYUOBOAWOQOFWTHUMIJCFQ3DYDO3ODHJZAXHST47FPSO5Q"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.6.4/nuget.exe" size="5338712"/>
+    </implementation>
+    <implementation id="sha1new=cf74e9cca0c76ff382efd9415008bf7a131c2222" released="2019-03-15" stability="stable" version="4.7.3">
+      <manifest-digest sha256new="IHE7G6DUIPNIR6IN4YNG5JDI5M4KSKLIZW3NXD6RMV6K3CRNCCKQ"/>
+      <file dest="nuget.exe" href="https://dist.nuget.org/win-x86-commandline/v4.7.3/nuget.exe" size="5434448"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="nuget" command="run"/>

--- a/editors/atom.xml
+++ b/editors/atom.xml
@@ -362,6 +362,38 @@
       <manifest-digest sha256new="BPMP7A6XYEU7J575NYYIK2ND2XFGBUHDV36HDRS2WILTYP32EISA"/>
       <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.34.0/atom-mac.zip" size="147990496" type="application/zip"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=fc10aa8edc4a0064ba035a9d6537f1b27adc6291" main="Atom.exe" released="2019-03-11" stability="stable" version="1.35.0">
+      <manifest-digest sha256new="ODSPL4W4PYMQ73JSY5CHIPJC65K42LW5IEUVK33BSKD2BXONKUSA"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.35.0/atom-x64-windows.zip" size="148122974" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=a760e79af041f013a664cb8841bcbcf6f303b623" main="Atom.exe" released="2019-03-11" stability="stable" version="1.35.0">
+      <manifest-digest sha256new="BBX3HJOGSUUI5QANBIUF2LAEUIZQZA4ITDZVHSTIMKEJPTW5MAVQ"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.35.0/atom-windows.zip" size="137606231" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=d4b616f9542f1b8d08bbba9f1ac5d9282bc3ade2" main="atom" released="2019-03-11" stability="stable" version="1.35.0">
+      <manifest-digest sha256new="TV2IN6IGLNED3MKOAH3CL2GIK7L7SBW5BO4UAPEQIKHZ4JBGF55Q"/>
+      <archive extract="atom-1.35.0-amd64" href="https://github.com/atom/atom/releases/download/v1.35.0/atom-amd64.tar.gz" size="141386678" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=0257a344428b4206952e27ecd252db28b243b66d" main="Contents/MacOS/Atom" released="2019-03-11" stability="stable" version="1.35.0">
+      <manifest-digest sha256new="J3HNEJJ77QXCTYNG3WVE5QZ2HS7AUXRRHUGKLVW2JWZRGULGA3MQ"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.35.0/atom-mac.zip" size="147859268" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=636430036c6a98edc08a2fc191fe6c4cddd38a8e" main="Atom.exe" released="2019-03-13" stability="stable" version="1.35.1">
+      <manifest-digest sha256new="HHALV5ZWTNYVSVTCDYYDH3NYGMR3LXW6ENQ333H2AORZTU6VNUSQ"/>
+      <archive extract="Atom x64" href="https://github.com/atom/atom/releases/download/v1.35.1/atom-x64-windows.zip" size="148127084" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=3c51b966dc55b5dc881909629334d6605187bc1f" main="Atom.exe" released="2019-03-13" stability="stable" version="1.35.1">
+      <manifest-digest sha256new="IFRDH5FPQOU3NKN63BBAZQART2NEO5UYS7ZU2PXHQI4W2725EF5A"/>
+      <archive extract="Atom" href="https://github.com/atom/atom/releases/download/v1.35.1/atom-windows.zip" size="137606796" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=8e213eb88d6e079238bee1b3b7a0f324f2c64f6d" main="atom" released="2019-03-13" stability="stable" version="1.35.1">
+      <manifest-digest sha256new="Z2UEDMONXE2U22XQX2ZJUNEAISQ7JKYFWJ3FPYGQPVXHLKSS76NA"/>
+      <archive extract="atom-1.35.1-amd64" href="https://github.com/atom/atom/releases/download/v1.35.1/atom-amd64.tar.gz" size="141380034" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-*" id="sha1new=9a039fd6f99ede2a9dce70c881b9b100cfba60a2" main="Contents/MacOS/Atom" released="2019-03-13" stability="stable" version="1.35.1">
+      <manifest-digest sha256new="4RA7QN3CSFFK5BZUDFY62MZ3CLDEJE2DQNVNVYU3I3M4DFIGMBNQ"/>
+      <archive extract="Atom.app" href="https://github.com/atom/atom/releases/download/v1.35.1/atom-mac.zip" size="147860335" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="atom" command="run"/>

--- a/editors/vs-code.xml
+++ b/editors/vs-code.xml
@@ -698,6 +698,70 @@
       <manifest-digest sha256new="RCDG6VZSE2MPYP53NVGHO6XSZSL4RRKMRWRIATUZNQ4YLPMX5IWA"/>
       <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/1b8e8302e405050205e69b59abb3559592bb9e60/code-stable-1549938199.tar.gz" size="68898043" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=ab59ed08601ac022828ce0ea9d5bc167d7ebb187" main="Code.exe" released="2019-03-14" stability="stable" version="1.32.0">
+      <manifest-digest sha256new="6YXSTXHHVRW5VNOM4S3HUAO5DY3WAGSS5KMEY4IERZG2QDY3FGKA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/507312a3e3b34b084b467dfd983263bc7c9d87e0/VSCode-win32-x64-1.32.0.zip" size="73536231" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=56b2ea8b13cc052e2768fa2928d2139d9e3cad9e" main="Code.exe" released="2019-03-14" stability="stable" version="1.32.0">
+      <manifest-digest sha256new="WBINXPE4N2GLCG3YONMYU5EVW5ZTMTA4PSKIMV4ZIQT6O43JFHJQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/507312a3e3b34b084b467dfd983263bc7c9d87e0/VSCode-win32-ia32-1.32.0.zip" size="64375205" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=66293d22116865b31e42c6122fb47f10035a6b25" main="bin/code" released="2019-03-14" stability="stable" version="1.32.0">
+      <manifest-digest sha256new="MQ3OO2PGH7GYTGW5T24D2LMGXTHTH52CHQ6ANOGK6SUMNP7QREZQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/507312a3e3b34b084b467dfd983263bc7c9d87e0/code-stable-1551898619.tar.gz" size="68076678" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=c522073c83385ce22873f5e83793b2d48d1273eb" main="bin/code" released="2019-03-14" stability="stable" version="1.32.0">
+      <manifest-digest sha256new="AEQZFGG53GGMARPGW6WICF6MXJX53UXMMERBMDSU53I36XCCEVSA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/507312a3e3b34b084b467dfd983263bc7c9d87e0/code-stable-1551898687.tar.gz" size="69073175" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=d1b45e79da8f8007db5a677daf98e56473c6d682" main="Code.exe" released="2019-03-14" stability="stable" version="1.32.1">
+      <manifest-digest sha256new="B5U4WMP3YKSRSIKQ22CPLZMYPDEQZ52B7YLHHSAADFCHAUEAX7RA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/05f146c7a8f7f78e80261aa3b2a2e642586f9eb3/VSCode-win32-x64-1.32.1.zip" size="73538329" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=05adc651c51aa6d698a57df8677d9b8dc7cca0c6" main="Code.exe" released="2019-03-14" stability="stable" version="1.32.1">
+      <manifest-digest sha256new="BMNINYAIOZEXUU47WC47MBTCSTSPI47HFIPPBSARDODU2ZATDUBQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/05f146c7a8f7f78e80261aa3b2a2e642586f9eb3/VSCode-win32-ia32-1.32.1.zip" size="64376116" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=881503f0e31c4af4db213e78e5f4120dc0945cea" main="bin/code" released="2019-03-14" stability="stable" version="1.32.1">
+      <manifest-digest sha256new="X3X6CZIWX2QTBUGEUXJ2XOINSKHTWBEOCWE5VCZ2KN2Y757YC2QQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/05f146c7a8f7f78e80261aa3b2a2e642586f9eb3/code-stable-1552006206.tar.gz" size="68075602" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=442754121634cf4c6a078aa0a7ec2060d0183a35" main="bin/code" released="2019-03-14" stability="stable" version="1.32.1">
+      <manifest-digest sha256new="JGYFHS4BL2TDWB4QEC4FUOCMHBKQB5HQAUJTJVFKQIZEZ7JH4MUQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/05f146c7a8f7f78e80261aa3b2a2e642586f9eb3/code-stable-1552006185.tar.gz" size="69072928" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=41fd0fc7fb2183c100dd8d33b481cfee76fc31e0" main="Code.exe" released="2019-03-14" stability="stable" version="1.32.2">
+      <manifest-digest sha256new="RITN2FEFBY7YBGZ7BMTX4W2QP6UAQNYWXRR7OPJMLNNKRB24P2JA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/e64cb27b1a0cbbc3f643c9fc6c7d93d6c6509951/VSCode-win32-x64-1.32.2.zip" size="73546654" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=6afab81f98d24a7afd892348e8615fe9d927a8b4" main="Code.exe" released="2019-03-14" stability="stable" version="1.32.2">
+      <manifest-digest sha256new="UTT4T24GOXO3I3WG7NB5R7W3HMGVUSXKM3I7YDACND3SIR2XGK2Q"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/e64cb27b1a0cbbc3f643c9fc6c7d93d6c6509951/VSCode-win32-ia32-1.32.2.zip" size="64383333" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=94696e138b014bc8d1a6bb33cab4a41e1c17184b" main="bin/code" released="2019-03-14" stability="stable" version="1.32.2">
+      <manifest-digest sha256new="YG772OJQI2QFA7WYYS7MF5FRGH2SX24GLLRUTC6TNPWBE7JT2EKQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/e64cb27b1a0cbbc3f643c9fc6c7d93d6c6509951/code-stable-1552488259.tar.gz" size="68081389" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=0810e9f8a66a48f7dc6e8776c6a0adf00dfca58f" main="bin/code" released="2019-03-14" stability="stable" version="1.32.2">
+      <manifest-digest sha256new="WQQOO4XHCTC2JB4NXHV6B573TLIGIHWKWCRRUDNQ6G6ACWUDDMFA"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/e64cb27b1a0cbbc3f643c9fc6c7d93d6c6509951/code-stable-1552488305.tar.gz" size="69058326" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=e0d6b1bcbf072a5029a611247eafa3c22b29fa6a" main="Code.exe" released="2019-03-15" stability="stable" version="1.32.3">
+      <manifest-digest sha256new="CAEB6M3X77DLU6EYMI4IWDPJXOLYOEICBC5LJT7PCZIUCPODQHJA"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/a3db5be9b5c6ba46bb7555ec5d60178ecc2eaae4/VSCode-win32-x64-1.32.3.zip" size="73546566" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=1a46e7e2cfc2545e79ee92f10e3788a77ed45985" main="Code.exe" released="2019-03-15" stability="stable" version="1.32.3">
+      <manifest-digest sha256new="DFAJKSIXGBZDKEOQKIFE26C23TXY6FII754SMC7BPGWIDGK2GNLQ"/>
+      <archive href="https://az764295.vo.msecnd.net/stable/a3db5be9b5c6ba46bb7555ec5d60178ecc2eaae4/VSCode-win32-ia32-1.32.3.zip" size="64378134" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=70177065f53190edadfa663f65f8ecc7a6f8f6db" main="bin/code" released="2019-03-15" stability="stable" version="1.32.3">
+      <manifest-digest sha256new="N3TAEBFHEMUQQL6AKTAZ7BVYHY6CXROSKKVBFU3RAVE3AGBFH3FQ"/>
+      <archive extract="VSCode-linux-x64" href="https://az764295.vo.msecnd.net/stable/a3db5be9b5c6ba46bb7555ec5d60178ecc2eaae4/code-stable-1552606946.tar.gz" size="68078974" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=b3f972cd8f0083fd0e34db312d6e4e4bf419f40a" main="bin/code" released="2019-03-15" stability="stable" version="1.32.3">
+      <manifest-digest sha256new="J3QGDR4BBVVZBUCGXWZ4DS3TCIC53WTRLJQDEPNOPBFSKQKWFRFQ"/>
+      <archive extract="VSCode-linux-ia32" href="https://az764295.vo.msecnd.net/stable/a3db5be9b5c6ba46bb7555ec5d60178ecc2eaae4/code-stable-1552604844.tar.gz" size="69060505" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="code" command="run"/>

--- a/golang/go-darwin.xml
+++ b/golang/go-darwin.xml
@@ -208,5 +208,13 @@
       <manifest-digest sha256new="F3LVBVXJ777HEXWH5NLBI2P556GRAHAER7CL7J5OXGXK7MTZXGDQ"/>
       <archive extract="go" href="https://dl.google.com/go/go1.12.darwin-amd64.tar.gz" size="126903500" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=9cfcf0b2e69e623cd483cf06fd67afdc791cd761" released="2019-03-14" stability="stable" version="1.11.6">
+      <manifest-digest sha256new="NLDJVND3YD2YAZGQOTRZE5CQDSAPCZ6YS7JEVRADU5RUU5ZEW6EA"/>
+      <archive extract="go" href="https://dl.google.com/go/go1.11.6.darwin-amd64.tar.gz" size="120491502" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=d7b10ee1ddd831a6b2b58701d286925b3333da9a" released="2019-03-14" stability="stable" version="1.12.1">
+      <manifest-digest sha256new="DISBWLEXV4TLBULX5NODLIWKIP6XZOE4J3MHJD6AP3XW4AHHGZYQ"/>
+      <archive extract="go" href="https://dl.google.com/go/go1.12.1.darwin-amd64.tar.gz" size="127582611" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
 </interface>

--- a/golang/go-linux.xml
+++ b/golang/go-linux.xml
@@ -468,5 +468,21 @@
       <manifest-digest sha256new="PCZ3T2KOCR7IAHCGKWY7JUPPRODE55OT32XX6NYLSZTR3R4AV2GQ"/>
       <archive extract="go" href="https://dl.google.com/go/go1.12.linux-386.tar.gz" size="108676281" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=ea08083d6df5d6e4bd77e777a568de93bd2dd8f6" released="2019-03-14" stability="stable" version="1.12.1">
+      <manifest-digest sha256new="7RXIXSC33DIOQAHCVC2CMGZST4CXNEXWPLWUDC3QBRPDLCP5P5MA"/>
+      <archive extract="go" href="https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz" size="127906702" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=7779cbd3bda975254de35c1d342c4d2c09f19e2d" released="2019-03-14" stability="stable" version="1.12.1">
+      <manifest-digest sha256new="EJKIREFSBNN3BVDIJ4VCILVLEQNUADHDTDPCY7B7WEF7UE7VRCOQ"/>
+      <archive extract="go" href="https://dl.google.com/go/go1.12.1.linux-386.tar.gz" size="109418341" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=06fa37c7e6c9e6d5487cc4a6143335034590ce8d" released="2019-03-14" stability="stable" version="1.11.6">
+      <manifest-digest sha256new="XG5BFQKHXIC2RKBGGJ6M4YZYIZ6EUHFLWZIL35WJGQNEOLTIEQAQ"/>
+      <archive extract="go" href="https://dl.google.com/go/go1.11.6.linux-amd64.tar.gz" size="121069423" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=6cf0a9c7e714c60f8693d85716e1ed34fbe4b4ed" released="2019-03-14" stability="stable" version="1.11.6">
+      <manifest-digest sha256new="KXOXDPWHB2RMHXDSNBZLTZ5GXF7F7LSL2VGSU4E7GIELLOPKLCYQ"/>
+      <archive extract="go" href="https://dl.google.com/go/go1.11.6.linux-386.tar.gz" size="104085784" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
 </interface>

--- a/golang/go-windows.xml
+++ b/golang/go-windows.xml
@@ -468,5 +468,21 @@
       <manifest-digest sha256new="5LSVVKFSLPL2KSXMRW3N52UENPJ3S7HVDHFVRD2OBBYEPM76C6JQ"/>
       <archive extract="SourceDir/Go" href="https://dl.google.com/go/go1.12.windows-386.msi" size="105877504" type="application/x-msi"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=c81c9a8a31d8cebea87ec963266e48bbd10801eb" released="2019-03-14" stability="stable" version="1.11.6">
+      <manifest-digest sha256new="VNSH2T57QDB4U6RMSWEVRNWP7OXX2KWPAUN2ZZBFPSBRQNNR7W4Q"/>
+      <archive extract="SourceDir/Go" href="https://dl.google.com/go/go1.11.6.windows-amd64.msi" size="116219904" type="application/x-msi"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=5762888b6671b9803220e9dac42c00cd840df2ac" released="2019-03-14" stability="stable" version="1.11.6">
+      <manifest-digest sha256new="SA7FBGGEEMWFAAAV544O2N2KKJD5KA2GUS2OIP6PODE5OZJS56GQ"/>
+      <archive extract="SourceDir/Go" href="https://dl.google.com/go/go1.11.6.windows-386.msi" size="100540416" type="application/x-msi"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=0b8a036e2b773085b12e0684cdf86b5022663609" released="2019-03-14" stability="stable" version="1.12.1">
+      <manifest-digest sha256new="Q4HDGXGPWJT73XG45GTKUYSKWHMQGI3MFSXYVXSYCVGFFEDQZOOQ"/>
+      <archive extract="SourceDir/Go" href="https://dl.google.com/go/go1.12.1.windows-amd64.msi" size="123396096" type="application/x-msi"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=2a808ae3cc49baff8af40615971879b0b7ea8b45" released="2019-03-14" stability="stable" version="1.12.1">
+      <manifest-digest sha256new="P46QXBAK6DGN6MXVLIPZGNEVJ6P6DQA6MCKP3PXLBZE3KWNHCDPA"/>
+      <archive extract="SourceDir/Go" href="https://dl.google.com/go/go1.12.1.windows-386.msi" size="106557440" type="application/x-msi"/>
+    </implementation>
   </group>
 </interface>

--- a/google/gcloud.xml
+++ b/google/gcloud.xml
@@ -976,6 +976,54 @@
       <manifest-digest sha256new="ZF7DCCNID5ENFADX7GAZKCYDBNS3XF5RJEUFINFN45CCCIFEIJ2A"/>
       <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-237.0.0-windows-x86.zip" size="124285136" type="application/zip"/>
     </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=dec491ee72bdbd430357b1d2cc9785803bd60b8e" released="2019-03-12" stability="stable" version="238.0.0">
+      <manifest-digest sha256new="MHFSIIUABG23E3IMKZNGNAMCH5A2RKMKYJFLJFKDZ6S6EKA3JEBQ"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-238.0.0-linux-x86_64.tar.gz" size="26128976" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=e6ad7d8917acfc5d9fd32b5e870911d1e31887f6" released="2019-03-12" stability="stable" version="238.0.0">
+      <manifest-digest sha256new="HKP6Q6REHUCDNP7J4KY5OSJVGXDRSJPGXDDMKSSSTL2GXD5SPKOQ"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-238.0.0-linux-x86.tar.gz" size="25734594" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=7535bd64c2f5c2b6d51ab1431ef1203757054ecf" released="2019-03-12" stability="stable" version="238.0.0">
+      <manifest-digest sha256new="GSSN6IFTETQIB37HDPKJVFHXGQ35AHIECEKSW6QTJ726656NMI5A"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-238.0.0-darwin-x86_64.tar.gz" size="18729964" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Darwin-i486" id="sha1new=70d607cf1f3f3649a5880e682a157c69c6950f98" released="2019-03-12" stability="stable" version="238.0.0">
+      <manifest-digest sha256new="CYXT56E42VP3PBRX32H4B7CWBEO7SDAJ46H65Q4JOASIW2TEYSQQ"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-238.0.0-darwin-x86.tar.gz" size="18730403" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=25ea03a137939dc49452268b5dac874303a83584" released="2019-03-12" stability="stable" version="238.0.0">
+      <manifest-digest sha256new="7KE6BU5N2NEVPXMVSNMTME5NJFAZQXTLNKNZDOLGLWXMWTCT4VHQ"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-238.0.0-windows-x86_64.zip" size="124685530" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=add1321f0e3dd8ec4166734920ce03a4e883d78e" released="2019-03-12" stability="stable" version="238.0.0">
+      <manifest-digest sha256new="SY67RGH5JI5JYMPUAFKOPN5WIGJGEQWK6N2BCAU2HBMDOPZS5IFA"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-238.0.0-windows-x86.zip" size="124793544" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=5eca12371f3328d7d896d451d11af639ab022f00" released="2019-03-19" stability="stable" version="239.0.0">
+      <manifest-digest sha256new="J4AV2Z3ZQ3J6UIHKCKLJRYJD7JYFNI2IYA4MBVQLBNW5VUVNPNXQ"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-239.0.0-linux-x86_64.tar.gz" size="26309874" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=7da014461f1183b181fc3d4bbce5a3450b289439" released="2019-03-19" stability="stable" version="239.0.0">
+      <manifest-digest sha256new="XZEZNAZZAB2WGOCN5FMPEZX63MQ6NNBSCOL2AS54ME4G3QZGYYBA"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-239.0.0-linux-x86.tar.gz" size="25915135" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=6a89123b713842df4a5522af43dbe55ebf44b776" released="2019-03-19" stability="stable" version="239.0.0">
+      <manifest-digest sha256new="2D36M6CG6E6JAMRGJNDEZXA6SA72P3YSDJWHNW4LWP4NRIK75BFA"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-239.0.0-darwin-x86_64.tar.gz" size="18911252" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Darwin-i486" id="sha1new=3cba3c4fd21a244737860809fc5b6a94059139a7" released="2019-03-19" stability="stable" version="239.0.0">
+      <manifest-digest sha256new="3ZMSKYT2XZYZVP6TMNS6FDCVSWJWLFYJAE2XYLA3WMQKBY7JZ6ZA"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-239.0.0-darwin-x86.tar.gz" size="18913836" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=3b656130164b3075bb0aebab69dd3f9569f7aaf2" released="2019-03-19" stability="stable" version="239.0.0">
+      <manifest-digest sha256new="LYR5ZXPEVL6CMPEBO3WIWJIQU2KRBEGU35IAZJPIDW7WYU2TXJ7A"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-239.0.0-windows-x86_64.zip" size="125923948" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=46ddea11eb26a40a1c95bde8c5ceea513740ede9" released="2019-03-19" stability="stable" version="239.0.0">
+      <manifest-digest sha256new="YIJ3MBM7RQGMVVDJ7OZWSPLS7VEKEOGLMVIX5Q3WGH5BC5T37PWQ"/>
+      <archive extract="google-cloud-sdk" href="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-239.0.0-windows-x86.zip" size="126031962" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="gcloud" command="run">

--- a/hashicorp/terraform.xml
+++ b/hashicorp/terraform.xml
@@ -357,6 +357,30 @@
         <manifest-digest sha256new="REE5BO4DQJ7LZZW7EQELK27TO5NIS3ZXZUZNXXWERHZXDVWEKGLQ"/>
         <archive href="https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_darwin_amd64.zip" size="22431061" type="application/zip"/>
       </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=4499def5be5f5d5af58c7fd0c44a7b12d70ee693" released="2019-03-08" stability="stable" version="0.11.12">
+        <manifest-digest sha256new="2G3HGJO3DEVQZX2LEHCAW5W2BM2D6FZY7JINFYOUVMAJF3TBRWWQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.12/terraform_0.11.12_linux_amd64.zip" size="21256854" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=a15e72f5596f8471ce1fd02fff5f2cff1b668b55" released="2019-03-08" stability="stable" version="0.11.12">
+        <manifest-digest sha256new="WJTTRGJNOHKTTA7ZKA2N3WTJYOBU4IBKAQUCLPUW6BXC5TAWDDVA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.12/terraform_0.11.12_linux_386.zip" size="19657106" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=98930ed22a6856bb6b047430301a2bb88e3c8775" released="2019-03-08" stability="stable" version="0.11.12">
+        <manifest-digest sha256new="GRDAJ3CDKTJ4LE4UDUOL3KWFZXVKLUAM445LTSHWP5E7ATEWHLLA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.12/terraform_0.11.12_darwin_amd64.zip" size="22722801" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=4ce68e287904756c2d39f3f467d836f757fdf3dd" released="2019-03-11" stability="stable" version="0.11.13">
+        <manifest-digest sha256new="K662W6CMQ2TRTGOU5ZVRSPPPURRDMWNUXVLMNO5TAA6BCNTF3NWQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip" size="21128942" type="application/zip"/>
+      </implementation>
+      <implementation arch="Linux-i386" id="sha1new=fb4f77c1cfea5fc73b0e709854c5890fcc9a4c0f" released="2019-03-11" stability="stable" version="0.11.13">
+        <manifest-digest sha256new="4JVGCKK7CGYNLPTDPHLPPNOTM2RJPMXLTL7V4RQ6R5LDNJ5M37XQ"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_386.zip" size="19539080" type="application/zip"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=920658bf4041e1f26e3b5fcf03f0800020ec6c5a" released="2019-03-11" stability="stable" version="0.11.13">
+        <manifest-digest sha256new="BGDXIZ5ZLV2KVJFYLDTKS2PB3VJQ6GBANG4FTFXJIVXPC2BU52CA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_darwin_amd64.zip" size="22547753" type="application/zip"/>
+      </implementation>
     </group>
     <group>
       <command name="run" path="terraform.exe"/>
@@ -591,6 +615,22 @@
       <implementation arch="Windows-i486" id="sha1new=8f8a698fbe79462f7dedbe4736ad966768a28ef5" released="2018-12-14" stability="stable" version="0.11.11">
         <manifest-digest sha256new="AFQVB5BBXXPIXKD7DWC6GJPLKDZEORHFKRAF2WUOOREUNWJQWU6Q"/>
         <archive href="https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_windows_386.zip" size="19340410" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=ec08bb357b0ba8ed4e7e444c822d8a49476d41a1" released="2019-03-08" stability="stable" version="0.11.12">
+        <manifest-digest sha256new="IDJFJWGETQ4ALTT2A5PV34MF2DJK6EWJVLVYJINQQNZGH7LPGJEA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.12/terraform_0.11.12_windows_amd64.zip" size="21285503" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=57275c76cfb6d1bd5eb373b765f0b032623d2828" released="2019-03-08" stability="stable" version="0.11.12">
+        <manifest-digest sha256new="5XMKBLY6ICAUKCR3KHXAGUDHUWKCHO64CTVD6JDVT74T2TWUWW4A"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.12/terraform_0.11.12_windows_386.zip" size="19618923" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=772747c8eb94b526f47ba14d57a47524d4d6abed" released="2019-03-11" stability="stable" version="0.11.13">
+        <manifest-digest sha256new="P7ML5V4NA56ZVTPLJ5REKDISCM42YFKE4VREYJWJIZ7RCYFTOBUA"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_windows_amd64.zip" size="21163715" type="application/zip"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=7e57aa215599469a2d05d5b3a979895ac34f9072" released="2019-03-11" stability="stable" version="0.11.13">
+        <manifest-digest sha256new="V7JVLMDV5MQUASHUWERWSGTWGQVBSE4MP5GCNTEQTO4QY6EXLA3Q"/>
+        <archive href="https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_windows_386.zip" size="19505552" type="application/zip"/>
       </implementation>
     </group>
   </group>

--- a/java/ant.xml
+++ b/java/ant.xml
@@ -146,6 +146,10 @@
       <manifest-digest sha256new="CXBENOFJGWGVD4OB7KSFQ7ALGMEZGHMFICORL7JCUAIX6A7OT3ZA"/>
       <archive extract="apache-ant-1.9.13" href="http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.13-bin.tar.gz" size="5829814" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation id="sha1new=b36f9634c402643905aef33f032a8cb1304ddf29" released="2019-03-17" stability="stable" version="1.9.14">
+      <manifest-digest sha256new="ZUUF6XXWU6MV2WAN2E2VMJY6PIQZQRSNCM2WLTYMKYFOIQWVQF4Q"/>
+      <archive extract="apache-ant-1.9.14" href="http://archive.apache.org/dist/ant/binaries/apache-ant-1.9.14-bin.tar.gz" size="5837539" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
   <entry-point binary-name="ant" command="run"/>
 </interface>

--- a/java/gradle.xml
+++ b/java/gradle.xml
@@ -877,6 +877,14 @@
       <manifest-digest sha256new="WFKATNMYBNWAJK2IAL5FNKRTLW3CCQ4CE53XKYMCLIWMQ4IDTDDA"/>
       <archive extract="gradle-5.3-rc-1" href="https://services.gradle.org/distributions/gradle-5.3-rc-1-bin.zip" size="87238414" type="application/zip"/>
     </implementation>
+    <implementation id="sha1new=4b3959ab01e33b77161e34f8764684bc19b789d5" released="2019-03-11" stability="testing" version="5.3-rc-2">
+      <manifest-digest sha256new="DYHFR7SIKABWLX62RV62VBTZXBAOUN4D4AI6RNY6BDILIVLLVEZQ"/>
+      <archive extract="gradle-5.3-rc-2" href="https://services.gradle.org/distributions/gradle-5.3-rc-2-bin.zip" size="87238800" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=d02d101ce159c89cc596304b61072f53b9420c9c" released="2019-03-13" stability="testing" version="5.3-rc-3">
+      <manifest-digest sha256new="N4B6NTUY3APPKYCHB7BMHKPLIWU4L4RXESBRX6TW36EXD52LNZRA"/>
+      <archive extract="gradle-5.3-rc-3" href="https://services.gradle.org/distributions/gradle-5.3-rc-3-bin.zip" size="87237886" type="application/zip"/>
+    </implementation>
   </group>
   <entry-point binary-name="gradle" command="run"/>
 </interface>

--- a/java/kotlin.xml
+++ b/java/kotlin.xml
@@ -252,6 +252,10 @@
       <manifest-digest sha256new="JLPEIJC7SECIFGKLK7ZPC4FVAIA2O6TL5P2Q3TVXL4RLKUQ7RKNA"/>
       <archive extract="kotlinc" href="https://github.com/JetBrains/kotlin/releases/download/v1.3.30-eap-11/kotlin-compiler-1.3.30-eap-11.zip" size="39904522" type="application/zip"/>
     </implementation>
+    <implementation id="sha1new=18438405101a82af0e3266b19ea83aa2efbba2e6" released="2019-03-15" stability="testing" version="1.3.30-pre-45">
+      <manifest-digest sha256new="R7XXP25PWVNT7R77VDVUTOLDT7QLGV63GRWK75FDTNOMJQ4HZI5Q"/>
+      <archive extract="kotlinc" href="https://github.com/JetBrains/kotlin/releases/download/v1.3.30-eap-45/kotlin-compiler-1.3.30-eap-45.zip" size="40125112" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="kotlin" command="run">

--- a/java/openjdk-12-jdk.watch.py
+++ b/java/openjdk-12-jdk.watch.py
@@ -1,0 +1,5 @@
+from urllib import request
+import re
+
+data = request.urlopen('http://jdk.java.net/12/').read().decode('utf-8')
+releases = [{'version': re.findall(r'\/jdk12\/GPL\/openjdk-([0-9\.]+)_', data)[0]}]

--- a/java/openjdk-12-jdk.xml
+++ b/java/openjdk-12-jdk.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/java/openjdk-12-jdk" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>openjdk-12-jdk</name>
+  <summary>OpenJDK Development Kit (JDK)</summary>
+  <description>OpenJDK is a development environment for building applications, applets, and
+components using the Java programming language.</description>
+  <homepage>http://jdk.java.net/12/</homepage>
+  <category>Development</category>
+
+  <feed-for interface="http://repo.roscidus.com/java/openjdk-jdk"/>
+
+  <group>
+    <!-- Some versions of JDK bundle their own copy of the JRE. For those that don't we refer back the regular JRE. -->
+    <command name="java">
+      <runner interface="http://repo.roscidus.com/java/openjdk-jre"/>
+    </command>
+    <command name="java-gui">
+      <runner interface="http://repo.roscidus.com/java/openjdk-jre" command="run-gui"/>
+    </command>
+
+    <package-implementation distributions="Debian" main="/usr/bin/javac" package="openjdk-12-jdk"/>
+    <package-implementation distributions="RPM" main="/usr/bin/javac" package="java-1.12.0-openjdk-devel"/>
+  </group>
+
+  <package-implementation distributions="Darwin" package="openjdk-1-jdk"/>
+  <package-implementation distributions="Windows" package="openjdk-1-jdk"/>
+
+  <group arch="Linux-x86_64" license="GNU General Public License, version 2, with the Classpath Exception">
+    <command name="run" path="bin/javac"/>
+    <command name="java" path="bin/java"/>
+    <command name="javap" path="bin/javap"/>
+    <command name="jar" path="bin/jar"/>
+    <command name="jarsigner" path="bin/jarsigner"/>
+    <command name="javadoc" path="bin/javadoc"/>
+    <command name="keytool" path="bin/keytool"/>
+    <command name="pack200" path="bin/pack200"/>
+    <command name="unpack200" path="bin/unpack200"/>
+    <command name="rmid" path="bin/rmid"/>
+    <command name="rmiregistry" path="bin/rmiregistry"/>
+    <command name="jjs" path="bin/jjs"/>
+    <command name="jrunscript" path="bin/jrunscript"/>
+    <command name="jaotc" path="bin/jaotc"/>
+    <command name="jcmd" path="bin/jcmd"/>
+    <command name="jconsole" path="bin/jconsole"/>
+    <command name="jdb" path="bin/jdb"/>
+    <command name="jdeprscan" path="bin/jdeprscan"/>
+    <command name="jdeps" path="bin/jdeps"/>
+    <command name="jfr" path="bin/jfr"/>
+    <command name="jhsdb" path="bin/jhsdb"/>
+    <command name="jimage" path="bin/jimage"/>
+    <command name="jinfo" path="bin/jinfo"/>
+    <command name="jlink" path="bin/jlink"/>
+    <command name="jmap" path="bin/jmap"/>
+    <command name="jmod" path="bin/jmod"/>
+    <command name="jps" path="bin/jps"/>
+    <command name="jshell" path="bin/jshell"/>
+    <command name="jstack" path="bin/jstack"/>
+    <command name="jstat" path="bin/jstat"/>
+    <command name="jstatd" path="bin/jstatd"/>
+    <command name="rmic" path="bin/rmic"/>
+    <command name="serialver" path="bin/serialver"/>
+
+    <implementation id="sha1new=8f83c322afb391eb4a2e345af82cd98d5f6d5fb3" released="2019-03-20" stability="stable" version="12">
+      <manifest-digest sha256new="5RREMEE5RUNTHELBZLSBKVO5A4ZXJAGPXQE5WFUISHC2O7AFXZJQ"/>
+      <archive extract="jdk-12" href="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_linux-x64_bin.tar.gz" size="197633782" type="application/x-compressed-tar"/>
+    </implementation>
+  </group>
+
+  <group arch="Windows-x86_64" license="GNU General Public License, version 2, with the Classpath Exception">
+    <command name="run" path="bin/javac.exe"/>
+    <command name="java" path="bin/java.exe"/>
+    <command name="java-gui" path="bin/javaw.exe"/>
+    <command name="javadoc" path="bin/javadoc.exe"/>
+    <command name="javap" path="bin/javap.exe"/>
+    <command name="jar" path="bin/jar.exe"/>
+    <command name="jarsigner" path="bin/jarsigner.exe"/>
+    <command name="keytool" path="bin/keytool.exe"/>
+    <command name="pack200" path="bin/pack200.exe"/>
+    <command name="unpack200" path="bin/unpack200.exe"/>
+    <command name="rmid" path="bin/rmid.exe"/>
+    <command name="rmiregistry" path="bin/rmiregistry.exe"/>
+    <command name="jjs" path="bin/jjs.exe"/>
+    <command name="jrunscript" path="bin/jrunscript.exe"/>
+    <command name="jaotc" path="bin/jaotc.exe"/>
+    <command name="jcmd" path="bin/jcmd.exe"/>
+    <command name="jconsole" path="bin/jconsole.exe"/>
+    <command name="jdb" path="bin/jdb.exe"/>
+    <command name="jdeprscan" path="bin/jdeprscan.exe"/>
+    <command name="jdeps" path="bin/jdeps.exe"/>
+    <command name="jfr" path="bin/jfr.exe"/>
+    <command name="jhsdb" path="bin/jhsdb.exe"/>
+    <command name="jimage" path="bin/jimage.exe"/>
+    <command name="jinfo" path="bin/jinfo.exe"/>
+    <command name="jlink" path="bin/jlink.exe"/>
+    <command name="jmap" path="bin/jmap.exe"/>
+    <command name="jmod" path="bin/jmod.exe"/>
+    <command name="jps" path="bin/jps.exe"/>
+    <command name="jshell" path="bin/jshell.exe"/>
+    <command name="jstack" path="bin/jstack.exe"/>
+    <command name="jstat" path="bin/jstat.exe"/>
+    <command name="jstatd" path="bin/jstatd.exe"/>
+    <command name="rmic" path="bin/rmic.exe"/>
+    <command name="serialver" path="bin/serialver.exe"/>
+    <command name="kinit" path="bin/kinit.exe"/>
+    <command name="klist" path="bin/klist.exe"/>
+    <command name="ktab" path="bin/ktab.exe"/>
+    <command name="jabswitch" path="bin/jabswitch.exe"/>
+    <command name="jaccessinspector" path="bin/jaccessinspector.exe"/>
+    <command name="jaccesswalker" path="bin/jaccesswalker.exe"/>
+
+    <implementation id="sha1new=75cba7a795fd308f2939bce444f90a6ab4016e8d" released="2019-03-20" stability="stable" version="12">
+      <manifest-digest sha256new="L4ZLTUHSB5NUWKUYK7VNNTFOBPNN5XPSBNVZWNHSUUAXEU6NKECQ"/>
+      <archive extract="jdk-12" href="https://download.java.net/java/GA/jdk12/GPL/openjdk-12_windows-x64_bin.zip" size="196405895" type="application/zip"/>
+    </implementation>
+  </group>
+</interface>

--- a/java/openjdk-12-jdk.xml.template
+++ b/java/openjdk-12-jdk.xml.template
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>openjdk-12-jdk</name>
+  <summary>OpenJDK Development Kit (JDK)</summary>
+  <description>OpenJDK is a development environment for building applications, applets, and
+components using the Java programming language.</description>
+  <homepage>http://jdk.java.net/12/</homepage>
+  <category>Development</category>
+
+  <feed-for interface="http://repo.roscidus.com/java/openjdk-12-jdk"/>
+
+  <group arch="Linux-x86_64" license="GNU General Public License, version 2, with the Classpath Exception">
+    <command name="run" path="bin/javac"/>
+    <command name="java" path="bin/java"/>
+    <command name="javap" path="bin/javap"/>
+    <command name="jar" path="bin/jar"/>
+    <command name="jarsigner" path="bin/jarsigner"/>
+    <command name="javadoc" path="bin/javadoc"/>
+    <command name="keytool" path="bin/keytool"/>
+    <command name="pack200" path="bin/pack200"/>
+    <command name="unpack200" path="bin/unpack200"/>
+    <command name="rmid" path="bin/rmid"/>
+    <command name="rmiregistry" path="bin/rmiregistry"/>
+    <command name="jjs" path="bin/jjs"/>
+    <command name="jrunscript" path="bin/jrunscript"/>
+    <command name="jaotc" path="bin/jaotc"/>
+    <command name="jcmd" path="bin/jcmd"/>
+    <command name="jconsole" path="bin/jconsole"/>
+    <command name="jdb" path="bin/jdb"/>
+    <command name="jdeprscan" path="bin/jdeprscan"/>
+    <command name="jdeps" path="bin/jdeps"/>
+    <command name="jfr" path="bin/jfr"/>
+    <command name="jhsdb" path="bin/jhsdb"/>
+    <command name="jimage" path="bin/jimage"/>
+    <command name="jinfo" path="bin/jinfo"/>
+    <command name="jlink" path="bin/jlink"/>
+    <command name="jmap" path="bin/jmap"/>
+    <command name="jmod" path="bin/jmod"/>
+    <command name="jps" path="bin/jps"/>
+    <command name="jshell" path="bin/jshell"/>
+    <command name="jstack" path="bin/jstack"/>
+    <command name="jstat" path="bin/jstat"/>
+    <command name="jstatd" path="bin/jstatd"/>
+    <command name="rmic" path="bin/rmic"/>
+    <command name="serialver" path="bin/serialver"/>
+
+    <implementation version="{version}" stability="stable">
+      <manifest-digest/>
+      <archive href="https://download.java.net/java/GA/jdk12/GPL/openjdk-{version}_linux-x64_bin.tar.gz" type="application/x-compressed-tar" extract="jdk-{version}"/>
+    </implementation>
+  </group>
+
+  <group arch="Windows-x86_64" license="GNU General Public License, version 2, with the Classpath Exception">
+    <command name="run" path="bin/javac.exe"/>
+    <command name="java" path="bin/java.exe"/>
+    <command name="java-gui" path="bin/javaw.exe"/>
+    <command name="javadoc" path="bin/javadoc.exe"/>
+    <command name="javap" path="bin/javap.exe"/>
+    <command name="jar" path="bin/jar.exe"/>
+    <command name="jarsigner" path="bin/jarsigner.exe"/>
+    <command name="keytool" path="bin/keytool.exe"/>
+    <command name="pack200" path="bin/pack200.exe"/>
+    <command name="unpack200" path="bin/unpack200.exe"/>
+    <command name="rmid" path="bin/rmid.exe"/>
+    <command name="rmiregistry" path="bin/rmiregistry.exe"/>
+    <command name="jjs" path="bin/jjs.exe"/>
+    <command name="jrunscript" path="bin/jrunscript.exe"/>
+    <command name="jaotc" path="bin/jaotc.exe"/>
+    <command name="jcmd" path="bin/jcmd.exe"/>
+    <command name="jconsole" path="bin/jconsole.exe"/>
+    <command name="jdb" path="bin/jdb.exe"/>
+    <command name="jdeprscan" path="bin/jdeprscan.exe"/>
+    <command name="jdeps" path="bin/jdeps.exe"/>
+    <command name="jfr" path="bin/jfr.exe"/>
+    <command name="jhsdb" path="bin/jhsdb.exe"/>
+    <command name="jimage" path="bin/jimage.exe"/>
+    <command name="jinfo" path="bin/jinfo.exe"/>
+    <command name="jlink" path="bin/jlink.exe"/>
+    <command name="jmap" path="bin/jmap.exe"/>
+    <command name="jmod" path="bin/jmod.exe"/>
+    <command name="jps" path="bin/jps.exe"/>
+    <command name="jshell" path="bin/jshell.exe"/>
+    <command name="jstack" path="bin/jstack.exe"/>
+    <command name="jstat" path="bin/jstat.exe"/>
+    <command name="jstatd" path="bin/jstatd.exe"/>
+    <command name="rmic" path="bin/rmic.exe"/>
+    <command name="serialver" path="bin/serialver.exe"/>
+    <command name="kinit" path="bin/kinit.exe"/>
+    <command name="klist" path="bin/klist.exe"/>
+    <command name="ktab" path="bin/ktab.exe"/>
+    <command name="jabswitch" path="bin/jabswitch.exe"/>
+    <command name="jaccessinspector" path="bin/jaccessinspector.exe"/>
+    <command name="jaccesswalker" path="bin/jaccesswalker.exe"/>
+
+    <implementation version="{version}" stability="stable">
+      <manifest-digest/>
+      <archive href="https://download.java.net/java/GA/jdk12/GPL/openjdk-{version}_windows-x64_bin.zip" type="application/zip" extract="jdk-{version}"/>
+    </implementation>
+  </group>
+</interface>

--- a/java/openjdk-jdk.xml
+++ b/java/openjdk-jdk.xml
@@ -16,6 +16,7 @@ components using the Java programming language.</description>
   <feed src="http://repo.roscidus.com/java/openjdk-9-jdk"/>
   <feed src="http://repo.roscidus.com/java/openjdk-10-jdk"/>
   <feed src="http://repo.roscidus.com/java/openjdk-11-jdk"/>
+  <feed src="http://repo.roscidus.com/java/openjdk-12-jdk"/>
 
   <group>
     <!-- Some versions of JDK bundle their own copy of the JRE. For those that don't we refer back the regular JRE. -->
@@ -145,6 +146,10 @@ components using the Java programming language.</description>
   </entry-point>
   <entry-point command="jdeps" binary-name="jdeps">
     <needs-terminal/>
+  </entry-point>
+  <entry-point command="jfr" binary-name="jfr">
+    <needs-terminal/>
+    <name>Tool for working with Flight Recorder files (.jfr)</name>
   </entry-point>
   <entry-point command="jhsdb" binary-name="jhsdb">
     <needs-terminal/>

--- a/javascript/electron.xml
+++ b/javascript/electron.xml
@@ -2746,6 +2746,106 @@
       <manifest-digest sha256new="DHW3HJSPNSAWUFNBHYDJALZRMIPANTLSUKXVSNF4IZY6KUWQVN3Q"/>
       <archive href="https://github.com/electron/electron/releases/download/v5.0.0-beta.5/electron-v5.0.0-beta.5-win32-ia32.zip" size="60708949" type="application/zip"/>
     </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=c5d500424de476ced5d6866214e000acfb5d8fb4" main="electron" released="2019-03-08" stability="stable" version="2.0.18">
+      <manifest-digest sha256new="CWYFXMYY5KBZ77DCTLJET6BICDO5ONA4QKW4Z25YLBSDTQA3SXDA"/>
+      <archive href="https://github.com/electron/electron/releases/download/v2.0.18/electron-v2.0.18-linux-x64.zip" size="48668416" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=4ec9fbf4cffca404e65b1920919f13d77dfeff55" main="electron" released="2019-03-08" stability="stable" version="2.0.18">
+      <manifest-digest sha256new="HRA5DON6SZXXTUNFOK4GCYC7OVO32O2SNKUZ5UVEPZLJBCHD264Q"/>
+      <archive href="https://github.com/electron/electron/releases/download/v2.0.18/electron-v2.0.18-linux-ia32.zip" size="51740958" type="application/zip"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=c2511d7b0beb6af2aa928852cebee5fbed7c8ab1" main="Electron.app/Contents/MacOS/Electron" released="2019-03-08" stability="stable" version="2.0.18">
+      <manifest-digest sha256new="HQBDQ2FQWJDLSUUQZU2S4KXGOHKX7YN4FW7A3E3F4YIVMYX36QYQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v2.0.18/electron-v2.0.18-darwin-x64.zip" size="48763235" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=25fb2fe619131e48ab528bfe2edb3a30b7cda0ec" main="electron.exe" released="2019-03-08" stability="stable" version="2.0.18">
+      <manifest-digest sha256new="BYXK6JEAMVM56PPXOJIBWWTBNBE4QZ2ID6UUPIKM2L6OQXG2Y54A"/>
+      <archive href="https://github.com/electron/electron/releases/download/v2.0.18/electron-v2.0.18-win32-x64.zip" size="50701803" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=55630e6d1526bf0d613e59a2532b09c19c570d73" main="electron.exe" released="2019-03-08" stability="stable" version="2.0.18">
+      <manifest-digest sha256new="BS2TQNIW2FY7IJNC7HS2BKNULO7MNBBEF7EF53IFUUEJLS2S46LA"/>
+      <archive href="https://github.com/electron/electron/releases/download/v2.0.18/electron-v2.0.18-win32-ia32.zip" size="42173364" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=86b4f94adfba5b4aa2cfa38004488ebae1e86de6" main="electron" released="2019-03-08" stability="stable" version="3.0.16">
+      <manifest-digest sha256new="SBLX7JM57RJDHSLE53AYYFZD7DK2SQPTT6L77456QVED2MXOJELQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.0.16/electron-v3.0.16-linux-x64.zip" size="51513985" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=aa3d273168581b9bca23cd0a43f65f0255354b54" main="electron" released="2019-03-08" stability="stable" version="3.0.16">
+      <manifest-digest sha256new="YVSFRF4S3TD4FHPSNEQ2O4JRGKRPHAVMU7PYKTDEYZNIV3KVT73Q"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.0.16/electron-v3.0.16-linux-ia32.zip" size="52551836" type="application/zip"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=8122e95b8d50738167848015e7531839631557fd" main="Electron.app/Contents/MacOS/Electron" released="2019-03-08" stability="stable" version="3.0.16">
+      <manifest-digest sha256new="SRYMLXPT7CYVP4BAPE4WSYCWJN7GSVWNW4SEEAJ4XRM2XL7XYP7Q"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.0.16/electron-v3.0.16-darwin-x64.zip" size="50153266" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=4e5c693a1a2dd6a3a4c33752a87a6248bd4423f8" main="electron.exe" released="2019-03-08" stability="stable" version="3.0.16">
+      <manifest-digest sha256new="NF35BKANAJYVA63EYR3QL3MPABBVLXFJ4HAQNUOS4TI5JDZ2WCYQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.0.16/electron-v3.0.16-win32-x64.zip" size="53159290" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=334625ce4a6a788a74d9c5885da11959053eb91f" main="electron.exe" released="2019-03-08" stability="stable" version="3.0.16">
+      <manifest-digest sha256new="UW2Y5C6F4TX5A2RBBA5O2GRQZKBPQF23XF4B2VTJIL7NFUWD3WHQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.0.16/electron-v3.0.16-win32-ia32.zip" size="44512479" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=e7bc459fb12aea1c4c6dd6be59d00a179d58b366" main="electron" released="2019-03-08" stability="stable" version="3.1.6">
+      <manifest-digest sha256new="GSUMDFRXUI6KTC7DIVO5JFJPXQ5CVXL6RUWYVELCBVML46VT4OTQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.1.6/electron-v3.1.6-linux-x64.zip" size="51575380" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=6e24b28219ceb88b9cf1bbe966012863febf277f" main="electron" released="2019-03-08" stability="stable" version="3.1.6">
+      <manifest-digest sha256new="IZR4KVBLR57HPQJIE3ODKQBRPNXZO6NEBFAIT2ATUUTKHRZDUEFQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.1.6/electron-v3.1.6-linux-ia32.zip" size="52599602" type="application/zip"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=3697bc2e95ec8837f9d0efe3b92f17cee8554ef1" main="Electron.app/Contents/MacOS/Electron" released="2019-03-08" stability="stable" version="3.1.6">
+      <manifest-digest sha256new="DNXXZQ6WHUMMCQJD6U6Q77A7THRIDTY5ND46L2NTZSND6MP4DK4A"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.1.6/electron-v3.1.6-darwin-x64.zip" size="50213550" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=e89f80468004fd99189871547ec9cc2715d2c940" main="electron.exe" released="2019-03-08" stability="stable" version="3.1.6">
+      <manifest-digest sha256new="XOMKXGXR4BNQEDXVCOGE4U4XGRGIOSPWURMKUJJYHU4ORXWZJXZQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.1.6/electron-v3.1.6-win32-x64.zip" size="53220641" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=b44f3f41a901ff66845c4fe2dbd1efe4036cafd0" main="electron.exe" released="2019-03-08" stability="stable" version="3.1.6">
+      <manifest-digest sha256new="BFGOV52NLM63BFYTMRC6EU5ZHIFSGDP6GET34VR4LGVFUHMEC5YA"/>
+      <archive href="https://github.com/electron/electron/releases/download/v3.1.6/electron-v3.1.6-win32-ia32.zip" size="44555876" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=5780e7580b469bf69746b9f64624258ec88d412e" main="electron" released="2019-03-08" stability="stable" version="4.0.8">
+      <manifest-digest sha256new="M2VYVNAMI24DMEF42Q2EP5HEGZSNCNVZWN6L7E6X22RQ5O3ALHNQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.0.8/electron-v4.0.8-linux-x64.zip" size="75146259" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=08d3aa5324acf865e3ef4f35aa3840686412fa40" main="electron" released="2019-03-08" stability="stable" version="4.0.8">
+      <manifest-digest sha256new="GFMPOQ2H2STGSIUR54LCAGI2X3RFOUW3BGD62NJ6W5B35EF2JK6A"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.0.8/electron-v4.0.8-linux-ia32.zip" size="78773206" type="application/zip"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=6d834e4bccbeca001241ae0083a399838fd23bba" main="Electron.app/Contents/MacOS/Electron" released="2019-03-08" stability="stable" version="4.0.8">
+      <manifest-digest sha256new="WOUJQPBEYVEI7ORID4ABMR4IX3JSCY4XSYIWR5HMFPH7D32KIBFA"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.0.8/electron-v4.0.8-darwin-x64.zip" size="54642638" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=f750f431bb2d17db921ff7b21ca076af97d10619" main="electron.exe" released="2019-03-08" stability="stable" version="4.0.8">
+      <manifest-digest sha256new="YN6JRZ2G6I4F3TKU2UNMYIOLBNDG3YYKNYCUWEILBJPVPTTF2JLQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.0.8/electron-v4.0.8-win32-x64.zip" size="60696873" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=8fbe0e6bcd94420a17017b23df3f47a1c1263c1c" main="electron.exe" released="2019-03-08" stability="stable" version="4.0.8">
+      <manifest-digest sha256new="77UJIAIGI5RNBIVQVFZUTP5A3PVPZWQEX4WOP72BTVKJIZHJWZTA"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.0.8/electron-v4.0.8-win32-ia32.zip" size="58114852" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=5ff85bafb720e72bf49c71171b8bd8a50999f3e7" main="electron" released="2019-03-14" stability="stable" version="4.1.0">
+      <manifest-digest sha256new="B6AIBUFBZBXYILIAWT2LUT3WIJ6WTXKTUDLIVHL2VO2DTC2526DQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.1.0/electron-v4.1.0-linux-x64.zip" size="75146294" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=c70ccd0fd8ce462e8dfcc5ca36caace09e6e4ebf" main="electron" released="2019-03-14" stability="stable" version="4.1.0">
+      <manifest-digest sha256new="HFDJ6MXZPHRJJYVX7JKX7MGTAQOELMEXO2DYJ3NLDPFN4ODBPGKQ"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.1.0/electron-v4.1.0-linux-ia32.zip" size="78773553" type="application/zip"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=c24022e97509baec53942f9f022d62b339ffa1f0" main="Electron.app/Contents/MacOS/Electron" released="2019-03-14" stability="stable" version="4.1.0">
+      <manifest-digest sha256new="FIH5JWN2NG4VQCAC6VBHJQ6WQOL2X3ZVDYZUHIRAHXY3CL3ERYRA"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.1.0/electron-v4.1.0-darwin-x64.zip" size="54641649" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=48d190d3d1053c2d65d67686d90e79386002d14e" main="electron.exe" released="2019-03-14" stability="stable" version="4.1.0">
+      <manifest-digest sha256new="UWYTGQL6URRPWMTK7DPUQJZAVYRXRRN6HK4PMBQKSYILCNOBKXIA"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.1.0/electron-v4.1.0-win32-x64.zip" size="60697106" type="application/zip"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=d460bfedf196af839f91ddbf5b442b13781556a9" main="electron.exe" released="2019-03-14" stability="stable" version="4.1.0">
+      <manifest-digest sha256new="D4MT3QMSQQ7YS6NOKMUMTC2D4IINJA5OHB5MMQL7M7UQBIYLLL2Q"/>
+      <archive href="https://github.com/electron/electron/releases/download/v4.1.0/electron-v4.1.0-win32-ia32.zip" size="58115775" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="electron" command="run"/>

--- a/javascript/node.xml
+++ b/javascript/node.xml
@@ -2257,6 +2257,14 @@
       <manifest-digest sha256new="NGJ3B5B6U3HM2JVUQ6LGADFPMPRNZHWS2GSREUBWWAT6A7343WKQ"/>
       <archive extract="node-v8.15.1-darwin-x64" href="https://nodejs.org/dist/v8.15.1/node-v8.15.1-darwin-x64.tar.gz" size="15334722" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=b110818b66cff0184622efe84ae326ae4b6df97d" released="2019-03-14" stability="testing" version="11.12.0">
+      <manifest-digest sha256new="UQ7WICY7OF7Y7HHH4MUAU2BA6PUC4OMV7TUIOA6CJGOLP6SH5PTQ"/>
+      <archive extract="node-v11.12.0-linux-x64" href="https://nodejs.org/dist/v11.12.0/node-v11.12.0-linux-x64.tar.xz" size="13217476" type="application/x-xz-compressed-tar"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=86620d26846dbd90539b618a5bb9c976e2f4af57" released="2019-03-14" stability="testing" version="11.12.0">
+      <manifest-digest sha256new="FDJAOJTPACUSO5NY7MQHCXV5MHHTY64Q4IQ4MIMTJXIEJ65SOO6Q"/>
+      <archive extract="node-v11.12.0-darwin-x64" href="https://nodejs.org/dist/v11.12.0/node-v11.12.0-darwin-x64.tar.gz" size="17767975" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
 
   <group license="MIT License">
@@ -3904,6 +3912,14 @@
     <implementation arch="Windows-i486" id="sha1new=e6231b4caac284ed481fc4bc8f3fa67b43c4ef52" released="2019-02-28" stability="stable" version="8.15.1">
       <manifest-digest sha256new="A2AUG4CNXMC3NIK3IZJ4PIQ64YZQVKK6APRSVP2VXWVYJCWS32MA"/>
       <archive extract="SourceDir/nodejs" href="https://nodejs.org/dist/v8.15.1/node-v8.15.1-x86.msi" size="14692352" type="application/x-msi"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=c5500ccef32c7f9199b18ebe13681c8b1da35c98" released="2019-03-14" stability="testing" version="11.12.0">
+      <manifest-digest sha256new="ETELO7MH34ORY7635T4INKKEHLCZGRTFR2XIRQORIHBK47M4PWFA"/>
+      <archive extract="SourceDir/nodejs" href="https://nodejs.org/dist/v11.12.0/node-v11.12.0-x64.msi" size="17412096" type="application/x-msi"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=0fbc1fb986737111da13726de1c51f9b7560fae2" released="2019-03-14" stability="testing" version="11.12.0">
+      <manifest-digest sha256new="Z5LMUWUKFWUXMFIPXO2OLC3CYKD2GEOBCWHLSDXTJX2IX4DY6TKA"/>
+      <archive extract="SourceDir/nodejs" href="https://nodejs.org/dist/v11.12.0/node-v11.12.0-x86.msi" size="15818752" type="application/x-msi"/>
     </implementation>
   </group>
 

--- a/kubernetes/helmfile.xml
+++ b/kubernetes/helmfile.xml
@@ -1410,6 +1410,26 @@
       <manifest-digest sha256new="ORW44JROE6RQQENT2PVB3T6FEW2YREHZAX3ARIYY6XHVGWYPWEZA"/>
       <file dest="helmfile" executable="true" href="https://github.com/roboll/helmfile/releases/download/v0.45.3/helmfile_darwin_amd64" size="10791736"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=4200f0eea04b29266e9c6af460af0f1c3a3cb8d9" main="helmfile.exe" released="2019-03-20" stability="stable" version="0.46.2">
+      <manifest-digest sha256new="DPRYLYPY3CKFQSWQ7KZBPIURPD426QWDGE6O54V2FX7NLVQCGTOA"/>
+      <file dest="helmfile.exe" href="https://github.com/roboll/helmfile/releases/download/v0.46.2/helmfile_windows_amd64.exe" size="10695168"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=f80d6124b87413dd32cdbe24f394d8627a6d54c8" main="helmfile.exe" released="2019-03-20" stability="stable" version="0.46.2">
+      <manifest-digest sha256new="P3YWVBWNL4NNDSAEWDNMEUB5DMNJZY4P7NBBBV7ZQ43Y2IKVOAEA"/>
+      <file dest="helmfile.exe" href="https://github.com/roboll/helmfile/releases/download/v0.46.2/helmfile_windows_386.exe" size="9474048"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=1b82cdc50313a0cdc744e572f45520434416ef74" main="helmfile" released="2019-03-20" stability="stable" version="0.46.2">
+      <manifest-digest sha256new="PUWPWDY3NBZYAIAR5NEBUKJNLPUUB2SE2JUI5WFXRQPDQZ3S3O7Q"/>
+      <file dest="helmfile" executable="true" href="https://github.com/roboll/helmfile/releases/download/v0.46.2/helmfile_linux_amd64" size="10902125"/>
+    </implementation>
+    <implementation arch="Linux-i486" id="sha1new=91286c57158b2fa9aa96f27ed333da9fadfa719a" main="helmfile" released="2019-03-20" stability="stable" version="0.46.2">
+      <manifest-digest sha256new="TTTBU5HP3ZVBA2IJAKDRGDIDV4WMYJSO4SUHIDRWNFKWWY5ID37A"/>
+      <file dest="helmfile" executable="true" href="https://github.com/roboll/helmfile/releases/download/v0.46.2/helmfile_linux_386" size="9648145"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=c1467607fc38a39c5a65fc45f74fa4455b446b16" main="helmfile" released="2019-03-20" stability="stable" version="0.46.2">
+      <manifest-digest sha256new="GSHR622N3AR4KTIRMPL3N34RTH6CM3PSI6ZHI6KWAHT5NBKBLLIQ"/>
+      <file dest="helmfile" executable="true" href="https://github.com/roboll/helmfile/releases/download/v0.46.2/helmfile_darwin_amd64" size="10791688"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="helmfile" command="run"/>

--- a/kubernetes/kubectl.xml
+++ b/kubernetes/kubectl.xml
@@ -1149,6 +1149,30 @@
         <manifest-digest sha256new="MFFMTG2KJ7R6RZKCYA7DGOM23EDAZTVVZFWJ635BSHS5X4REEN6A"/>
         <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-beta.1/kubernetes-client-darwin-amd64.tar.gz" size="12981958" type="application/x-compressed-tar"/>
       </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=b5e291aa01f7c164722770eb85f40e3280a425c5" released="2019-03-12" stability="testing" version="1.14.0-pre2-2">
+        <manifest-digest sha256new="FXPZ574TVWNF7354U6AFAOB44SS23JM45L2JDRVP5MXCW6CB357Q"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-beta.2/kubernetes-client-linux-amd64.tar.gz" size="13370013" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=a1da6ea3ae9634a67db9c225a20dbbc9e5aed25e" released="2019-03-12" stability="testing" version="1.14.0-pre2-2">
+        <manifest-digest sha256new="7KJARTAY4DKKZGSWBNW66OR2IEV2A6ZEGPZWJNQKNKNNYMYG5FNA"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-beta.2/kubernetes-client-linux-386.tar.gz" size="12502207" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=d9da6662e9cbe29a8c4ab3e3d468e1dd2e6aabab" released="2019-03-12" stability="testing" version="1.14.0-pre2-2">
+        <manifest-digest sha256new="CA2FTA6MD2XFJUUCEZSTGJYEGTVGIK755BQMYAON3UUGBQAWWKEQ"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-beta.2/kubernetes-client-darwin-amd64.tar.gz" size="14041950" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-x86_64" id="sha1new=db8c1ab059ac7676fa1bd23e0a3fcbf802abc2e4" released="2019-03-19" stability="testing" version="1.14.0-rc1">
+        <manifest-digest sha256new="FEIWTKZGDZ6BEXN7DVZVAJETYWUJLU6PWOF5LSKYW7I6M6FRASYQ"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-rc.1/kubernetes-client-linux-amd64.tar.gz" size="13406564" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Linux-i486" id="sha1new=4ac13093d5316a36aa008ed3b60480c0ff36db57" released="2019-03-19" stability="testing" version="1.14.0-rc1">
+        <manifest-digest sha256new="AMLWUBHQSOUMQPR4HF3KLPWVUQGKSQOB7VMX3TXX3E2XDDMSP3HQ"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-rc.1/kubernetes-client-linux-386.tar.gz" size="12541292" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Darwin-x86_64" id="sha1new=89911436fdc1d9c0fb68b7f13f30851e4ba51f58" released="2019-03-19" stability="testing" version="1.14.0-rc1">
+        <manifest-digest sha256new="XPIYD5VEK4VABGN272BTJDJDXNG6ENCJKLGAU7LEYTA5RWF5WHWQ"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-rc.1/kubernetes-client-darwin-amd64.tar.gz" size="14077164" type="application/x-compressed-tar"/>
+      </implementation>
     </group>
     <group>
       <command name="run" path="client/bin/kubectl.exe"/>
@@ -1911,6 +1935,22 @@
       <implementation arch="Windows-i486" id="sha1new=eff260bdb49b356a24a58114c20d47faa6e64a81" released="2019-02-26" stability="testing" version="1.14.0-pre2-1">
         <manifest-digest sha256new="HUC5V3WXWTQ47KELRVHIVXWCPTB2A77TLYWKIW5DZBPVMTEPUY2A"/>
         <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-beta.1/kubernetes-client-windows-386.tar.gz" size="11557525" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=2a88ba93ef0dcdc0e25c965a4dc56dceb5aabf67" released="2019-03-12" stability="testing" version="1.14.0-pre2-2">
+        <manifest-digest sha256new="O7IOY4AKPYT3KIBC55AQBDHLFHE7KRU7XFRODNNANARSZPOUHLDA"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-beta.2/kubernetes-client-windows-amd64.tar.gz" size="13432387" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=09257f29345ab12a7eab1e7ee13524c26c68b78c" released="2019-03-12" stability="testing" version="1.14.0-pre2-2">
+        <manifest-digest sha256new="G5OYVXDJSMMUX3ZOGGMK5DXPO5K4ZGODTC2TRSIEDSZFI777DMQQ"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-beta.2/kubernetes-client-windows-386.tar.gz" size="12538407" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=46c0ad5835f175fc0019c4dcd3d347311595da07" released="2019-03-19" stability="testing" version="1.14.0-rc1">
+        <manifest-digest sha256new="GZHQKVSXTJDQPVQWE2P6OPFJLCQUEZL6V7S6MNGYYOMDO7WQIYXQ"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-rc.1/kubernetes-client-windows-amd64.tar.gz" size="13466062" type="application/x-compressed-tar"/>
+      </implementation>
+      <implementation arch="Windows-i486" id="sha1new=831804eb4803514c9470139e178499dc7c57fb3f" released="2019-03-19" stability="testing" version="1.14.0-rc1">
+        <manifest-digest sha256new="YTDEK4GTRSWTFLSCC4MLOMEP6YH5JQJN2EDNF5BIHSLD642QJDOQ"/>
+        <archive extract="kubernetes" href="https://dl.k8s.io/v1.14.0-rc.1/kubernetes-client-windows-386.tar.gz" size="12574501" type="application/x-compressed-tar"/>
       </implementation>
     </group>
   </group>

--- a/python/python.watch.py
+++ b/python/python.watch.py
@@ -2,7 +2,7 @@ from urllib import request
 import re
 from datetime import datetime
 
-skipped_versions = ['3.5.5rc1', '3.5.5', '3.5.6rc1', '3.5.6', '3.5.7rc1']
+skipped_versions = ['3.5.5rc1', '3.5.5', '3.5.6rc1', '3.5.6', '3.5.7rc1', '3.5.7']
 
 def convert(match):
     version_full = match[0] # e.g. 3.7.2rc2

--- a/python/python.xml
+++ b/python/python.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" ?>
-<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
 <interface uri="http://repo.roscidus.com/python/python" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
   <name>python</name>
   <summary>interactive high-level object-oriented language</summary>
@@ -18,8 +17,7 @@ language for applications that need a programmable interface.</description>
 
   <feed src="http://repo.roscidus.com/python/python/upstream.xml"/>
 
-  <group>
-    <!-- There is a separate GUI version of the Python executable on Windows. On POSIX systems we simply map it back to regular Python. -->
+  <group><!-- There is a separate GUI version of the Python executable on Windows. On POSIX systems we simply map it back to regular Python. -->
     <command name="run-gui">
       <runner interface="http://repo.roscidus.com/python/python"/>
     </command>
@@ -43,7 +41,7 @@ language for applications that need a programmable interface.</description>
     <package-implementation distributions="Arch" main="/usr/bin/python2" package="python2"/>
     <package-implementation distributions="Arch" main="/usr/bin/python3" package="python"/>
 
-    <package-implementation distributions="Ports" main="/usr/local/bin/python" package="python"/> 
+    <package-implementation distributions="Ports" main="/usr/local/bin/python" package="python"/>
     <package-implementation distributions="Ports" main="/usr/local/bin/python2.5" package="python25"/>
     <package-implementation distributions="Ports" main="/usr/local/bin/python2.6" package="python26"/>
     <package-implementation distributions="Ports" main="/usr/local/bin/python2.7" package="python27"/>
@@ -52,8 +50,7 @@ language for applications that need a programmable interface.</description>
     <package-implementation distributions="MacPorts" main="/opt/local/bin/python2.6" package="python26"/>
     <package-implementation distributions="MacPorts" main="/opt/local/bin/python2.7" package="python27"/>
   </group>
-
-  <!-- Python for Windows 2.7.x -->
+<!-- Python for Windows 2.7.x -->
   <group license="Python License">
     <command name="run" path="python.exe"/>
     <command name="run-gui" path="pythonw.exe"/>
@@ -79,8 +76,7 @@ language for applications that need a programmable interface.</description>
       <archive extract="SourceDir" href="https://www.python.org/ftp/python/2.7.15/python-2.7.15.msi" size="19304448" type="application/x-msi"/>
     </implementation>
   </group>
-
-  <!-- Python for Windows 3.4.x -->
+<!-- Python for Windows 3.4.x -->
   <group>
     <command name="run" path="python.exe"/>
     <command name="run-gui" path="pythonw.exe"/>
@@ -97,17 +93,16 @@ language for applications that need a programmable interface.</description>
       <manifest-digest sha1new="173ef9fd3010d8e2e2ee19c56e03d93e794b6011" sha256="13b8550d444d6659ec6685c17a674a671de52c4609a1ecc6731ef8c726664bf1" sha256new="CO4FKDKEJVTFT3DGQXAXUZ2KM4O6KLCGBGQ6ZRTTD34MOJTGJPYQ"/>
       <archive extract="SourceDir" href="https://www.python.org/ftp/python/3.4.3/python-3.4.3.msi" size="24846336" type="application/x-msi"/>
     </implementation>
-    <implementation arch="Windows-x86_64" id="sha1new=8477d8f12220dfb26f68ed773d33125d2e2d18c3" released="2015-12-21" version="3.4.4" stability="stable">
+    <implementation arch="Windows-x86_64" id="sha1new=8477d8f12220dfb26f68ed773d33125d2e2d18c3" released="2015-12-21" stability="stable" version="3.4.4">
       <manifest-digest sha256new="4C5WBENNBKC7SZMGOEP7OMQDBSNLOYIUU2QTUCCHCYBSUSSETY4Q"/>
       <archive extract="SourceDir" href="https://www.python.org/ftp/python/3.4.4/python-3.4.4.amd64.msi" size="26054656" type="application/x-msi"/>
     </implementation>
-    <implementation arch="Windows-i486" id="sha1new=3c32a3b7bb96e734514e3e9e4a9c33eae4ed2025" released="2015-12-21" version="3.4.4" stability="stable">
+    <implementation arch="Windows-i486" id="sha1new=3c32a3b7bb96e734514e3e9e4a9c33eae4ed2025" released="2015-12-21" stability="stable" version="3.4.4">
       <manifest-digest sha256new="RJSQEABOVDBHIHG5NO5T52GEUPSA27GZZK6QOCRPSX76X6Z5L3PQ"/>
       <archive extract="SourceDir" href="https://www.python.org/ftp/python/3.4.4/python-3.4.4.msi" size="24932352" type="application/x-msi"/>
     </implementation>
   </group>
-
-  <!-- Python for Windows >= 3.5 -->
+<!-- Python for Windows >= 3.5 -->
   <group>
     <command name="run" path="python.exe"/>
     <command name="run-gui" path="pythonw.exe"/>
@@ -685,6 +680,20 @@ language for applications that need a programmable interface.</description>
       <manifest-digest sha256new="ZJUGT4WXR6FUZX4Z6MVFHS2WG57E7Z333O7ZAZDT6PVUU7M757OQ"/>
       <recipe>
         <archive href="https://www.python.org/ftp/python/3.7.2/python-3.7.2-embed-win32.zip" size="6590778" type="application/zip"/>
+        <remove path="python37._pth"/>
+      </recipe>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=7d12d2f9f7e706ddca3c7c186e0da9ba7ed538b8" released="2019-03-12" stability="testing" version="3.7.3-rc1">
+      <manifest-digest sha256new="O53SHSJSA7RIKB6GJMKLBZW677BGKZXD2GEJKOULE4DQIBDYTRCQ"/>
+      <recipe>
+        <archive href="https://www.python.org/ftp/python/3.7.3/python-3.7.3rc1-embed-amd64.zip" size="7019029" type="application/zip"/>
+        <remove path="python37._pth"/>
+      </recipe>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=55faceaa9b514ab3d9d664a2e9e4b3774b5b653b" released="2019-03-12" stability="testing" version="3.7.3-rc1">
+      <manifest-digest sha256new="W4D26M7OJGSSIOP6TYHMMSX5BZFA5ZG6PLW47ONOW6OP5QWVFOWQ"/>
+      <recipe>
+        <archive href="https://www.python.org/ftp/python/3.7.3/python-3.7.3rc1-embed-win32.zip" size="6526592" type="application/zip"/>
         <remove path="python37._pth"/>
       </recipe>
     </implementation>

--- a/python/pyyaml.xml
+++ b/python/pyyaml.xml
@@ -59,5 +59,13 @@
       <manifest-digest sha256new="QKECRJ2RLLSJHQPHLHLDHDJMZPUL3BS5N5DSC2CHA7YORIFNEYUA"/>
       <archive extract="pyyaml-4.1" href="https://github.com/yaml/pyyaml/archive/4.1.tar.gz" size="158341" type="application/x-compressed-tar"/>
     </implementation>
+    <implementation id="sha1new=f9e1e3db443cd0f41a4607832eb5bd2dca8ae5bc" released="2018-07-05" stability="stable" version="3.13">
+      <manifest-digest sha256new="GO33TS3RCOIORR265FOQL2UZFJVCZ2FVF7UHAPF62RNCWT34R7NQ"/>
+      <archive extract="pyyaml-3.13" href="https://github.com/yaml/pyyaml/archive/3.13.tar.gz" size="157868" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation id="sha1new=c6c6348230fd1af52466cee5b28b90dfa7baa594" released="2019-03-13" stability="stable" version="5.1">
+      <manifest-digest sha256new="CIVXEQGXLXFOG444KMWOHTJV37D2RKI3IOA4W43VPPCVULKQRJCQ"/>
+      <archive extract="pyyaml-5.1" href="https://github.com/yaml/pyyaml/archive/5.1.tar.gz" size="164288" type="application/x-compressed-tar"/>
+    </implementation>
   </group>
 </interface>

--- a/utils/chocolatey.xml
+++ b/utils/chocolatey.xml
@@ -362,6 +362,14 @@
       <manifest-digest sha256new="24TLCPVFA25LBBVNM2XL7Q4CPIJCZFFWZK2HWOSHMWTBGAAEFNMQ"/>
       <archive extract="tools" href="https://chocolatey.org/api/v2/package/chocolatey/0.9.10-beta-20160320" size="5891494" type="application/zip"/>
     </implementation>
+    <implementation id="sha1new=482506d41f8e96a20a4b0345e3804f4a85f7e3ab" released="2019-03-15" stability="stable" version="0.10.12">
+      <manifest-digest sha256new="3SA7OC6GKKJW7IDT7INUBQXAA6OUCNAMGNIFWA2B76LJV3C3RFDQ"/>
+      <archive extract="tools" href="https://chocolatey.org/api/v2/package/chocolatey/0.10.12" size="4064224" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=3759833bae5cbe2fc6927a8b1fb857d912396df3" released="2019-03-15" stability="stable" version="0.10.13">
+      <manifest-digest sha256new="4HFPASZGWS2746VIXFRNTT6D6AXX2MYKVVMTTD3ZMTFBHRQJS2XA"/>
+      <archive extract="tools" href="https://chocolatey.org/api/v2/package/chocolatey/0.10.13" size="4064469" type="application/zip"/>
+    </implementation>
   </group>
 
   <entry-point binary-name="choco" command="run"/>

--- a/utils/curl.xml
+++ b/utils/curl.xml
@@ -283,13 +283,13 @@
       <manifest-digest sha256new="WPBA7YQ2UXZ4L3X4S6WGEYHNOGLDB6AIR2UJYWG2Q2V2V2JBGXQQ"/>
       <archive extract="curl-7.63.0-win32-mingw" href="https://bintray.com/vszakats/generic/download_file?file_path=curl-7.63.0-win32-mingw.tar.xz" size="2049216" type="application/x-xz-compressed-tar"/>
     </implementation>
-    <implementation arch="Windows-x86_64" id="sha1new=1ed19054d4ac2157074091abdc78825379dd818b" released="2019-02-06" stability="stable" version="7.64.0">
-      <manifest-digest sha256new="6WBOHNQA2I5JO4WOAUNVNHVMD6GQK5ZCXBJS3OXJW6H4BTWJDNSA"/>
-      <archive extract="curl-7.64.0-win64-mingw" href="https://bintray.com/vszakats/generic/download_file?file_path=curl-7.64.0-win64-mingw.tar.xz" size="2150708" type="application/x-xz-compressed-tar"/>
+    <implementation arch="Windows-x86_64" id="sha1new=45a4ab70081e21e1a3a0a10ddfebdca95e2b42d9" released="2019-03-08" stability="stable" version="7.64.0">
+      <manifest-digest sha256new="KQ3RO4ADSPYITORAY6COF6NAQVWX77WRIVT3HO4FEDZPGDEDEC3Q"/>
+      <archive extract="curl-7.64.0-win64-mingw" href="https://bintray.com/vszakats/generic/download_file?file_path=curl-7.64.0-win64-mingw.tar.xz" size="2154764" type="application/x-xz-compressed-tar"/>
     </implementation>
-    <implementation arch="Windows-i486" id="sha1new=4dbc5be201979ed5fdd5fce665f150dd423d72c7" released="2019-02-06" stability="stable" version="7.64.0">
-      <manifest-digest sha256new="SDJEQ3IKSFNTQO3NUXP5CIJI4AAJCWKVSBXE3ANNKH4Z2W56MQAQ"/>
-      <archive extract="curl-7.64.0-win32-mingw" href="https://bintray.com/vszakats/generic/download_file?file_path=curl-7.64.0-win32-mingw.tar.xz" size="2007492" type="application/x-xz-compressed-tar"/>
+    <implementation arch="Windows-i486" id="sha1new=295d8d2cce1f2b052784c0aae757e1847dce9339" released="2019-03-08" stability="stable" version="7.64.0">
+      <manifest-digest sha256new="BYXGFTJYL74BAJCYJMEFARSNIKJTJC3VFOAWQ5N545RHH6K4TZIA"/>
+      <archive extract="curl-7.64.0-win32-mingw" href="https://bintray.com/vszakats/generic/download_file?file_path=curl-7.64.0-win32-mingw.tar.xz" size="2010668" type="application/x-xz-compressed-tar"/>
     </implementation>
   </group>
 

--- a/utils/filezilla.xml
+++ b/utils/filezilla.xml
@@ -3177,5 +3177,31 @@
       <manifest-digest sha256new="SZ2LBGLC2C2M75KVMLA7JLTVZ44JZUV3JYCXWX3LE27OT3WU4XWQ"/>
       <archive extract="filezilla-3.41.1" href="https://download.filezilla-project.org/client/FileZilla_3.41.1_src.tar.bz2" size="4994973" type="application/x-bzip-compressed-tar"/>
     </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=5e7932a55aa345446344b8b2c003b84b10cf3d4c" main="filezilla.exe" released="2019-03-18" stability="stable" version="3.41.2">
+      <manifest-digest sha256new="2CMGACKYNZA4W5KEK7SZP5GEOAK5WIL72GKS4G3SLUKHQ5WS45BQ"/>
+      <recipe>
+        <archive extract="FileZilla-3.41.2" href="https://download.filezilla-project.org/client/FileZilla_3.41.2_win64.zip" size="11407528" type="application/zip"/>
+        <archive href="filezilla.config.zip" size="332" type="application/zip"/>
+      </recipe>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=410e6cba190aad181ae8303cbd7e1999481ae863" main="filezilla.exe" released="2019-03-18" stability="stable" version="3.41.2">
+      <manifest-digest sha256new="25EFFLQOMNATSH7QOUYO5NOXHQONKI2A2JFX5LBRLS3I3NKOYKHA"/>
+      <recipe>
+        <archive extract="FileZilla-3.41.2" href="https://download.filezilla-project.org/client/FileZilla_3.41.2_win32.zip" size="11819451" type="application/zip"/>
+        <archive href="filezilla.config.zip" size="332" type="application/zip"/>
+      </recipe>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=4da8b853315c00e678334ea1db45e3391f1420ee" main="bin/filezilla" released="2019-03-18" stability="stable" version="3.41.2">
+      <manifest-digest sha256new="VYKEJ75DHY3BLI5BBGWTGOYCEAYZWWERJCLKNM2JBEGRZDX54F2Q"/>
+      <archive extract="FileZilla3" href="https://download.filezilla-project.org/client/FileZilla_3.41.2_x86_64-linux-gnu.tar.bz2" size="9217386" type="application/x-bzip-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-i686" id="sha1new=12c7c4a2b9d8d716d488530c3b31c3bd11aa0ea6" main="Contents/MacOS/filezilla" released="2019-03-18" stability="stable" version="3.41.2">
+      <manifest-digest sha256new="3JPTM4AU4G2L7PP4X6FDKVWWSBFQP2ANZSZXISFAZZMJ7TFZVWZA"/>
+      <archive extract="FileZilla.app" href="https://download.filezilla-project.org/client/FileZilla_3.41.2_macosx-x86.app.tar.bz2" size="10700517" type="application/x-bzip-compressed-tar"/>
+    </implementation>
+    <implementation arch="*-src" id="sha1new=161fae7310d0384c90a0b82b2f12bc7bf118a03d" released="2019-03-18" stability="stable" version="3.41.2">
+      <manifest-digest sha256new="FAS67CTORHJEAGKCQ7OBM5B4TIXLPSD55E4TQR6GWIOWHT3WKDIQ"/>
+      <archive extract="filezilla-3.41.2" href="https://download.filezilla-project.org/client/FileZilla_3.41.2_src.tar.bz2" size="4994803" type="application/x-bzip-compressed-tar"/>
+    </implementation>
   </group>
 </interface>


### PR DESCRIPTION
These commits were created by [this AppVeyor CI job](https://ci.appveyor.com/project/0install/repo-roscidus-com/build/job/he7e3f6tkvd5yxmt).

@talex5 I was wondering whether it would be better to squash these commits to keep the Git history less noisy or to preserve them to show all the individual XML snippets that were fed into 0repo. What do you prefer?