### PR TITLE
Added Google Cloud SQL Proxy

### DIFF
--- a/google/cloudsql-proxy.watch.py
+++ b/google/cloudsql-proxy.watch.py
@@ -1,0 +1,7 @@
+from urllib import request
+import json
+
+excluded_versions = ['1.05', '1.06', '1.07', '1.08', '1.09', '1.10', '1.11', '1.12']
+
+data = request.urlopen('https://api.github.com/repos/GoogleCloudPlatform/cloudsql-proxy/releases').read().decode('utf-8')
+releases = [{'version': release['tag_name'], 'released': release['published_at'][0:10]} for release in json.loads(data) if release['tag_name'] not in excluded_versions]

--- a/google/cloudsql-proxy.xml
+++ b/google/cloudsql-proxy.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/google/cloudsql-proxy" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Cloud SQL Proxy</name>
+  <summary>allows user to connect to Cloud SQL without IP whitelisting or SSL certificates</summary>
+  <description>The Cloud SQL Proxy allows a user with the appropriate permissions to connect to a Second Generation Cloud SQL database without having to deal with IP whitelisting or SSL certificates manually.</description>
+  <homepage>https://cloud.google.com/sql/docs/mysql/sql-proxy</homepage>
+  <needs-terminal/>
+
+  <group license="Apache License 2.0">
+    <implementation arch="Windows-x86_64" id="sha1new=179cc54872273031b2a1d84e85e188bb04e995e2" main="cloud_sql_proxy.exe" released="2018-10-10" stability="stable" version="1.13">
+      <manifest-digest sha256new="HPFILAPRDU3UMLJL3JQ5ULIPWHZPHNEAC6CH4BIL4VJ7ZCYVTI4Q"/>
+      <file dest="cloud_sql_proxy.exe" href="https://storage.googleapis.com/cloudsql-proxy/v1.13/cloud_sql_proxy_x64.exe" size="7293440"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=0a69195f870ced0d5d27cb799884142d08372256" main="cloud_sql_proxy.exe" released="2018-10-10" stability="stable" version="1.13">
+      <manifest-digest sha256new="HXSOSZUF74TWQHO7P2OVWNDYVTP76PQWHLSWP6LQ2AGVEI2XOI3Q"/>
+      <file dest="cloud_sql_proxy.exe" href="https://storage.googleapis.com/cloudsql-proxy/v1.13/cloud_sql_proxy_x86.exe" size="6409216"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=1929ab605371106dbcfbb02a7e9d9d3d2f99142f" main="cloud_sql_proxy" released="2018-10-10" stability="stable" version="1.13">
+      <manifest-digest sha256new="5FLXSKTSWGQZYZK4CUCVCG5JWSAMPLHGVCU2ZWKULKPUCFRG2KYQ"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.13/cloud_sql_proxy.linux.amd64" size="7955768"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=3b7ef25ae5c27eaba798346f04a30df2d24b98a3" main="cloud_sql_proxy" released="2018-10-10" stability="stable" version="1.13">
+      <manifest-digest sha256new="55ZQ7FVLN57NX34OJE7DMLQ7F7EP6QHNDHQBHFAICCTWFPJ7J7OQ"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.13/cloud_sql_proxy.linux.386" size="6993667"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=f1fb8451f0de87c063bde99ad44505b3b68a8680" main="cloud_sql_proxy" released="2018-10-10" stability="stable" version="1.13">
+      <manifest-digest sha256new="HB6ZKIWCQT6Y74BJA32VZUMZZJQ52MDGCBINO5SG3H55C76QI2AQ"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.13/cloud_sql_proxy.darwin.amd64" size="7859800"/>
+    </implementation>
+    <implementation arch="Darwin-i386" id="sha1new=1f98060d37f3bbf4517b2ddb2c78e2f4d89b252a" main="cloud_sql_proxy" released="2018-10-10" stability="stable" version="1.13">
+      <manifest-digest sha256new="ND3JLA4CLTR7YKFBXUMOB6BZGWOCZVTZNTXPSFBPSCRHAQOFXMOQ"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.13/cloud_sql_proxy.darwin.386" size="6919932"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=f1f815b339848c7201211ab528b894d9cc120558" main="cloud_sql_proxy.exe" released="2019-04-18" stability="stable" version="1.14">
+      <manifest-digest sha256new="FJ2NPRUSYGBH3FGAP4765EKUTMVU2WKTIBLUJML6SRIYEES6ZPUA"/>
+      <file dest="cloud_sql_proxy.exe" href="https://storage.googleapis.com/cloudsql-proxy/v1.14/cloud_sql_proxy_x64.exe" size="12285952"/>
+    </implementation>
+    <implementation arch="Windows-i486" id="sha1new=0b1b6045466497990ad8b9d0e764e15134c6b96b" main="cloud_sql_proxy.exe" released="2019-04-18" stability="stable" version="1.14">
+      <manifest-digest sha256new="UK2QQF3NQAOJDQK2DJ7HYUG2ZTMZW25XMBLPS7ZSUZTPXNDMGVAQ"/>
+      <file dest="cloud_sql_proxy.exe" href="https://storage.googleapis.com/cloudsql-proxy/v1.14/cloud_sql_proxy_x86.exe" size="10827264"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=912419994abf6bdffc45620ad99d338ea2b44e07" main="cloud_sql_proxy" released="2019-04-18" stability="stable" version="1.14">
+      <manifest-digest sha256new="XMUS6H2MFYTRKZKP2TUMG2M6PQYIQAWZ74MIVSSC4FQTEE2ZDIWQ"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.14/cloud_sql_proxy.linux.amd64" size="13068633"/>
+    </implementation>
+    <implementation arch="Linux-i386" id="sha1new=50ff95b6ef8535ca99e0dd8d889dafa15216d97c" main="cloud_sql_proxy" released="2019-04-18" stability="stable" version="1.14">
+      <manifest-digest sha256new="5L5G4ZQBFRFKLPD5MSDCPXQZYCGCLU5PBH5YZYN7JXN44VLA3M6A"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.14/cloud_sql_proxy.linux.386" size="11511369"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" id="sha1new=77bf845797de594627a89ae79b6919a5c1aacd4a" main="cloud_sql_proxy" released="2019-04-18" stability="stable" version="1.14">
+      <manifest-digest sha256new="ILNTKITCNBMAGKUJYO56A3TILD24EVZLNC7DW2KK4U5ABV2PFDVQ"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.14/cloud_sql_proxy.darwin.amd64" size="12886152"/>
+    </implementation>
+    <implementation arch="Darwin-i386" id="sha1new=f1076096433f75a71c1f57502f5b7cbfd60ade56" main="cloud_sql_proxy" released="2019-04-18" stability="stable" version="1.14">
+      <manifest-digest sha256new="33IANJDWT4WYZPCE3SGMU4DWRFJYM6WM65MGN7PK7QS43INPAF7Q"/>
+      <file dest="cloud_sql_proxy" executable="true" href="https://storage.googleapis.com/cloudsql-proxy/v1.14/cloud_sql_proxy.darwin.386" size="11368872"/>
+    </implementation>
+  </group>
+
+  <entry-point binary-name="cloud_sql_proxy" command="run"/>
+</interface>

--- a/google/cloudsql-proxy.xml.template
+++ b/google/cloudsql-proxy.xml.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Cloud SQL Proxy</name>
+  <summary>allows user to connect to Cloud SQL without IP whitelisting or SSL certificates</summary>
+  <description>The Cloud SQL Proxy allows a user with the appropriate permissions to connect to a Second Generation Cloud SQL database without having to deal with IP whitelisting or SSL certificates manually.</description>
+  <homepage>https://cloud.google.com/sql/docs/mysql/sql-proxy</homepage>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/google/cloudsql-proxy"/>
+
+  <group license="Apache License 2.0">
+    <implementation arch="Windows-x86_64" version="{version}" stability="stable" released="{released}" main="cloud_sql_proxy.exe">
+      <manifest-digest/>
+      <file href="https://storage.googleapis.com/cloudsql-proxy/v{version}/cloud_sql_proxy_x64.exe" dest="cloud_sql_proxy.exe"/>
+    </implementation>
+    <implementation arch="Windows-i486" version="{version}" stability="stable" released="{released}" main="cloud_sql_proxy.exe">
+      <manifest-digest/>
+      <file href="https://storage.googleapis.com/cloudsql-proxy/v{version}/cloud_sql_proxy_x86.exe" dest="cloud_sql_proxy.exe"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" version="{version}" stability="stable" released="{released}" main="cloud_sql_proxy">
+      <manifest-digest/>
+      <file href="https://storage.googleapis.com/cloudsql-proxy/v{version}/cloud_sql_proxy.linux.amd64" dest="cloud_sql_proxy" executable="true"/>
+    </implementation>
+    <implementation arch="Linux-i386" version="{version}" stability="stable" released="{released}" main="cloud_sql_proxy">
+      <manifest-digest/>
+      <file href="https://storage.googleapis.com/cloudsql-proxy/v{version}/cloud_sql_proxy.linux.386" dest="cloud_sql_proxy" executable="true"/>
+    </implementation>
+    <implementation arch="Darwin-x86_64" version="{version}" stability="stable" released="{released}" main="cloud_sql_proxy">
+      <manifest-digest/>
+      <file href="https://storage.googleapis.com/cloudsql-proxy/v{version}/cloud_sql_proxy.darwin.amd64" dest="cloud_sql_proxy" executable="true"/>
+    </implementation>
+    <implementation arch="Darwin-i386" version="{version}" stability="stable" released="{released}" main="cloud_sql_proxy">
+      <manifest-digest/>
+      <file href="https://storage.googleapis.com/cloudsql-proxy/v{version}/cloud_sql_proxy.darwin.386" dest="cloud_sql_proxy" executable="true"/>
+    </implementation>
+  </group>
+</interface>


### PR DESCRIPTION
Updated `google/index.html`:

```html
<!DOCTYPE html>
<html>
  <head>
    <title>repo.roscidus.com: Google</title>
  </head>
  <body>
    <h1>repo.roscidus.com: Google</h1>

    <p>To add common Google Cloud command-line tools to your <code>PATH</code>:</p>
    <pre>
      $ 0alias gcloud http://repo.roscidus.com/google/gcloud
      $ 0alias gsutil http://repo.roscidus.com/google/gcloud gsutil
      $ 0alias bq http://repo.roscidus.com/google/gcloud bq
      $ 0alias cloud_sql_proxy http://repo.roscidus.com/google/cloudsql-proxy
    </pre>

    <h2>Available feeds</h2>

    <ul>
      <li><a href='gcloud'>Google Cloud SDK</a></li>
      <li><a href='cloudsql-proxy'>Google Cloud SQL Proxy</a></li>
    </ul>
  </body>
</html>

```