### PR TITLE
Added Zenmap

### DIFF
--- a/python/python-cairo.xml
+++ b/python/python-cairo.xml
@@ -35,11 +35,11 @@
       <manifest-digest sha256new="266MVTT4XWMYWQWFN2PWFACNH42TRTBDA2VSSRT7SACA44KULB2A" />
       <archive href="http://ftp.gnome.org/pub/GNOME/binaries/win32/pycairo/1.8/pycairo-1.8.10.win32-py2.7.msi" size="147456" type="application/x-msi" extract="SourceDir/Lib/site-packages" />
     </implementation>
-    <implementation arch="Windows-x86_64" version="1.10.0" stability="stable" id="sha1new=b9b71efede8a8abd6df73c5e0e8b7eac1db0f795">
+    <implementation arch="Windows-x86_64" version="1.10.0" stability="developer" id="sha1new=b9b71efede8a8abd6df73c5e0e8b7eac1db0f795">
       <manifest-digest sha256new="TGTXCGTCARXN5K42WXVGKXMTVIXOMMXMGLRTOLETSPS62L6P3VMQ" />
       <archive href="pycairo_gtk-1.10.0-cp27-none-win_amd64.whl" size="29176" type="application/zip" />
     </implementation>
-    <implementation arch="Windows-i486" version="1.10.0" stability="stable" id="sha1new=e6380430b93ea83a185f810f8b160d8b0a620dd1">
+    <implementation arch="Windows-i486" version="1.10.0" stability="developer" id="sha1new=e6380430b93ea83a185f810f8b160d8b0a620dd1">
       <manifest-digest sha256new="VTDYMK6G7VIG6IQ7LVWVPAM2Y5MUH3NFHXLJY5LRMEMH3I7JOWTA" />
       <archive href="pycairo_gtk-1.10.0-cp27-none-win32.whl" size="25791" type="application/zip" />
     </implementation>

--- a/python/python-gobject.xml
+++ b/python/python-gobject.xml
@@ -50,11 +50,11 @@ the core library used to build GTK+ and GNOME.
       <manifest-digest sha256new="GTWVISPUFHUCTTJGWC5PW2NYRWGSVES4HBRZ5O3H4K22S4UT5X4Q" />
       <archive href="http://ftp.gnome.org/pub/GNOME/binaries/win32/pygobject/2.28/pygobject-2.28.3.win32-py2.7.msi" size="442368" type="application/x-msi" extract="SourceDir/Lib/site-packages" />
     </implementation>
-    <implementation arch="Windows-x86_64" version="2.28.6" stability="stable" id="sha1new=26307f0d01d2658495b0922c644e9b415e645406">
+    <implementation arch="Windows-x86_64" version="2.28.6" stability="developer" id="sha1new=26307f0d01d2658495b0922c644e9b415e645406">
       <manifest-digest sha256new="P4GNQDM7UJRU7JLJDXE6DAG5UJNVTTLHCIXHEHWR5KXPKKQ5HNQA" />
       <archive href="pygobject-2.28.6-cp27-none-win_amd64.whl" size="538211" type="application/zip" />
     </implementation>
-    <implementation arch="Windows-i486" version="2.28.6" stability="stable" id="sha1new=2ead3fbcf68cf5b175a536581a943ced35259d46">
+    <implementation arch="Windows-i486" version="2.28.6" stability="developer" id="sha1new=2ead3fbcf68cf5b175a536581a943ced35259d46">
       <manifest-digest sha256new="VSYQ2X6A6BRVRCRYEYDXAXN2BUEGEJNI6O6SI7CXQELZKVJVCLGQ" />
       <archive href="pygobject-2.28.6-cp27-none-win32.whl" size="511973" type="application/zip" />
     </implementation>

--- a/python/python-gtk.xml
+++ b/python/python-gtk.xml
@@ -23,11 +23,11 @@
       <manifest-digest sha256new="XHJCZH3BXCJ4T75HQ63JXU6URTXAE5WIAMWSD2UXUYF4LATFVIIQ" />
       <archive href="pygtk-2.22.0-cp27-none-win_amd64.whl" size="963000" type="application/zip" />
     </implementation>
-    <implementation arch="Windows-i486" version="2.22.0" stability="stable" id="sha1new=870fd5d1c2968e3da44232f492064a69ec70c0b8">
+    <implementation arch="Windows-i486" version="2.22.0" stability="developer" id="sha1new=870fd5d1c2968e3da44232f492064a69ec70c0b8">
       <manifest-digest sha256new="674477UGD7YPVU4RYTGPVJ5EIXVQJJFIVB5YZ6C7Q66JZJREZJQA" />
       <archive href="pygtk-2.22.0-cp27-none-win32.whl" size="757169" type="application/zip" />
     </implementation>
-    <implementation arch="Windows-i486" version="2.24.0" released="2011-04-10" stability="stable" id="sha1new=f29642fc00bdfa2a64b443c0a5f94dfb3ed72c99">
+    <implementation arch="Windows-i486" version="2.24.0" released="2011-04-10" stability="developer" id="sha1new=f29642fc00bdfa2a64b443c0a5f94dfb3ed72c99">
       <manifest-digest sha256new="5NQCQXEZAJRXGOM6H4Z4AXIBG4R7Z5RSBCRB5RFZHXNN2NMNIPTQ" />
       <archive href="http://ftp.gnome.org/pub/GNOME/binaries/win32/pygtk/2.24/pygtk-2.24.0.win32-py2.7.msi" size="835584" type="application/x-msi" extract="SourceDir/Lib/site-packages" />
     </implementation>

--- a/security/zenmap.xml
+++ b/security/zenmap.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/security/zenmap" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Zenmap</name>
+  <summary>Nmap frontend and results viewer</summary>
+  <homepage>https://nmap.org/zenmap/</homepage>
+  <icon href="https://raw.githubusercontent.com/0install/repo.roscidus.com/master/security/nmap.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/repo.roscidus.com/master/security/nmap.png" type="image/png"/>
+  <category>Network</category>
+  <category>Utility</category>
+
+  <package-implementation main="/usr/bin/zenmap" package="zenmap"/>
+
+  <group doc-dir="usr/share/zenmap/doc" license="modfied GPL">
+    <command name="run" path="zenmap.py">
+      <runner interface="http://repo.roscidus.com/python/python" version="2..!3"/>
+    </command>
+    <requires interface="http://repo.roscidus.com/python/python-gtk"/>
+    <requires interface="http://repo.roscidus.com/security/nmap">
+      <executable-in-path name="nmap"/>
+      <executable-in-path command="ncat" name="ncat"/>
+      <executable-in-path command="nping" name="nping"/>
+      <executable-in-path command="ndiff" name="ndiff"/>
+    </requires>
+    <environment insert="." name="ZENMAP_PREFIX"/>
+    <environment insert="usr/lib/python2.6/site-packages" name="PYTHONPATH"/>
+
+    <implementation id="sha1new=2f1f3db589d95b457d7c7f1793fe62ba8d067b8a" released="2018-03-20" stability="stable" version="7.70">
+      <manifest-digest sha256new="BJ4ZS7YAT7322U3FDZALNVREO2HXN6EBDGBIXFJZ3A2P6VW4PBIA"/>
+      <archive href="zenmap-7.70.zip" size="1249103" type="application/zip"/>
+    </implementation>
+  </group>
+</interface>

--- a/security/zenmap.xml.template
+++ b/security/zenmap.xml.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Zenmap</name>
+  <summary xml:lang="en">Nmap frontend and results viewer</summary>
+  <icon href="https://raw.githubusercontent.com/0install/repo.roscidus.com/master/security/nmap.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/repo.roscidus.com/master/security/nmap.png" type="image/png"/>
+  <category>Network</category>
+  <category>Utility</category>
+
+  <feed-for interface="http://repo.roscidus.com/security/zenmap"/>
+
+  <group doc-dir="usr/share/zenmap/doc" license="modfied GPL">
+    <command name="run" path="zenmap.py">
+      <runner interface="http://repo.roscidus.com/python/python" version="2..!3"/>
+    </command>
+    <requires interface="http://repo.roscidus.com/python/python-gtk"/>
+    <requires interface="http://repo.roscidus.com/security/nmap">
+      <executable-in-path name="nmap"/>
+      <executable-in-path command="ncat" name="ncat"/>
+      <executable-in-path command="nping" name="nping"/>
+      <executable-in-path command="ndiff" name="ndiff"/>
+    </requires>
+    <environment insert="." name="ZENMAP_PREFIX"/>
+    <environment insert="usr/lib/python2.6/site-packages" name="PYTHONPATH"/>
+
+    <implementation version="{version}" released="{released}" stability="stable">
+      <manifest-digest/>
+      <archive href="zenmap-{version}.zip" type="application/zip"/>
+    </implementation>
+  </group>
+</interface>


### PR DESCRIPTION
New entry for `security/index.html`:
```html
<dt><a href='zenmap'>Zenmap</a></dt><dd>Nmap frontend and results viewer</dd>
```

For this PR [zenmap-7.70.zip](https://github.com/0install/repo.roscidus.com/files/3342069/zenmap-7.70.zip) needs to be added to `incoming/`. I created this archive by:

1. Downloading and extracting https://nmap.org/dist/zenmap-7.70-1.noarch.rpm.
1. Adding a `zenmap.py` launcher script:
   ```python
   import zenmapGUI.App
   zenmapGUI.App.run()
   ```
1. Applying the following patch:
    ```diff
    --- a/usr/lib/python2.6/site-packages/zenmapCore/Paths.py
    +++ b/usr/lib/python2.6/site-packages/zenmapCore/Paths.py
    @@ -159,13 +159,13 @@ def get_prefix():
     
     prefix = get_prefix()
     
    -# These lines are overwritten by the installer to hard-code the installed
    -# locations.
    -CONFIG_DIR = '/usr/share/zenmap/config'
    -LOCALE_DIR = '/usr/share/zenmap/locale'
    -MISC_DIR = '/usr/share/zenmap/misc'
    -PIXMAPS_DIR = '/usr/share/zenmap/pixmaps'
    -DOCS_DIR = '/usr/share/zenmap/docs'
    +# The following lines are patched for Zero Install compatability.
    +import os
    +CONFIG_DIR = os.environ['ZENMAP_PREFIX'] + '/usr/share/zenmap/config'
    +LOCALE_DIR = os.environ['ZENMAP_PREFIX'] + '/usr/share/zenmap/locale'
    +MISC_DIR = os.environ['ZENMAP_PREFIX'] + '/usr/share/zenmap/misc'
    +PIXMAPS_DIR = os.environ['ZENMAP_PREFIX'] + '/usr/share/zenmap/pixmaps'
    +DOCS_DIR = os.environ['ZENMAP_PREFIX'] + '/usr/share/zenmap/docs'
     NMAPDATADIR = '/usr/share/nmap'
    ```

In order to get Zenmap to work on Windows, I had to reduce the stability rating of certain Windows builds of PyGObject, PyCairo and PyGTK. These versions seem to have issues with imports, but I didn't yet have the time to diagnose this more deeply. By reducing their stability rating instead of removing them, they can still be selected if there are no alternatives available (e.g. for 64-bit processes).