### PR TITLE
add glut

### DIFF
--- a/lib/glut.xml
+++ b/lib/glut.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://repo.roscidus.com/lib/glut" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>FreeGLUT</name>
+  <summary xml:lang="en">FreeGLUT is a free-software/open-source alternative to the OpenGL Utility Toolkit (GLUT) library.</summary>
+  <description xml:lang="en">GLUT was originally written by Mark Kilgard to support the sample programs in the second edition OpenGL 'RedBook'. Since then, GLUT has been used in a wide variety of practical applications because it is simple, widely available and highly portable.
+
+GLUT (and hence FreeGLUT) takes care of all the system-specific chores required for creating windows, initializing OpenGL contexts, and handling input events, to allow for trully portable OpenGL programs.</description>
+  <category>Graphics</category>
+  <homepage>http://freeglut.sourceforge.net/</homepage>
+  <package-implementation package="media-libs/freeglut" distributions="Gentoo"/>
+  <package-implementation package="freeglut"/>
+  <feed arch="Windows-*" src="http://0install.de/feeds/glut.xml"/>
+</interface>
+


### PR DESCRIPTION
include cross distribution and Gentoo package-implementation 
import Windows feed created in https://github.com/0install/0install.de-feeds/pull/25

The distribution package-implementation all use freeGLUT. 
It is binary compatible with the original GLUT which is packaged for Windows in pull 25
