### PR TITLE
update expat  

### DIFF
--- a/lib/expat1.xml
+++ b/lib/expat1.xml
@@ -7,6 +7,8 @@
 This package contains the runtime, shared library of expat, the C library for
 parsing XML.</description>
   <package-implementation package="libexpat1"/>
+  <package-implementation package="expat"/>
+  <package-implementation ditributions="Gentoo" package="dev-libs/expat"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=9b893d18c4fa1fcea73f35cd97d9c82c9d8fe2a6" released="2010-04-04" version="2.0.1-4">
       <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-i386-2.0.1-4+lenny3.tar.bz2" size="102310"/>
@@ -21,5 +23,15 @@ parsing XML.</description>
       <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-amd64-2.0.1-7.tar.bz2" size="106257"/>
     </implementation>
   </group>
+  <implementation arch="Windows-*" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" license="MIT/X Consortium License" released="2000-10-22" version="1.95.1">
+    <manifest-digest sha256new="KBPHRCHXWQYXNJTXGUMRFMJVUJJ3YAM4JCBAHLRGJSDBCM6LTQKA"/>
+    <archive extract="expat_win32bin_1_95_1" href="https://sourceforge.net/projects/expat/files/expat_win32/1.95.1/expat_win32bin_1_95_1.zip" size="119596" type="application/zip"/>
+  </implementation>
+  <implementation arch="Windows-*" id="1.95.1withdllrenamed" license="MIT/X Consortium License" released="2000-10-22" version="1.95.0">
+    <manifest-digest sha256new="MCUPVDSVDVI5DJ63BTG2MI53FG23LX2CL6SDSKCNZO6RUZOLWTCQ"/>
+    <recipe>
+      <copy-from dest="libexpat.dll" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" source="expat_1_95_1.dll"/>
+    </recipe>
+  </implementation>
 
 </interface>

--- a/lib/expat1.xml
+++ b/lib/expat1.xml
@@ -23,11 +23,6 @@ parsing XML.</description>
       <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-amd64-2.0.1-7.tar.bz2" size="106257"/>
     </implementation>
   </group>
-  <implementation arch="Windows-*" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" license="MIT/X Consortium License" released="2000-10-22" version="1.95.1">
-    <manifest-digest sha256new="KBPHRCHXWQYXNJTXGUMRFMJVUJJ3YAM4JCBAHLRGJSDBCM6LTQKA"/>
-    <archive extract="expat_win32bin_1_95_1" href="https://sourceforge.net/projects/expat/files/expat_win32/1.95.1/expat_win32bin_1_95_1.zip" size="119596" type="application/zip"/>
-    <archive href="https://github.com/libexpat/libexpat/releases/download/R_1_95_1/expat_win32bin_1_95_1.zip?raw=true" size="119596" type="application/zip" extract="expat_win32bin_1_95_1" />
-  </implementation>
   <implementation arch="Windows-*" version="1.95.0" released="2000-10-22" license="MIT/X Consortium License" id="1.95.1withdllrenamed">
     <manifest-digest sha256new="NIFBMKJZ277BARKR4SOXWRHPTW45IL3NBJM76PZZD4GVCYV6RHQQ" />
     <recipe>

--- a/lib/expat1.xml
+++ b/lib/expat1.xml
@@ -26,11 +26,17 @@ parsing XML.</description>
   <implementation arch="Windows-*" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" license="MIT/X Consortium License" released="2000-10-22" version="1.95.1">
     <manifest-digest sha256new="KBPHRCHXWQYXNJTXGUMRFMJVUJJ3YAM4JCBAHLRGJSDBCM6LTQKA"/>
     <archive extract="expat_win32bin_1_95_1" href="https://sourceforge.net/projects/expat/files/expat_win32/1.95.1/expat_win32bin_1_95_1.zip" size="119596" type="application/zip"/>
+    <archive href="https://github.com/libexpat/libexpat/releases/download/R_1_95_1/expat_win32bin_1_95_1.zip?raw=true" size="119596" type="application/zip" extract="expat_win32bin_1_95_1" />
   </implementation>
-  <implementation arch="Windows-*" id="1.95.1withdllrenamed" license="MIT/X Consortium License" released="2000-10-22" version="1.95.0">
-    <manifest-digest sha256new="MCUPVDSVDVI5DJ63BTG2MI53FG23LX2CL6SDSKCNZO6RUZOLWTCQ"/>
+  <implementation arch="Windows-*" version="1.95.0" released="2000-10-22" license="MIT/X Consortium License" id="1.95.1withdllrenamed">
+    <manifest-digest sha256new="NIFBMKJZ277BARKR4SOXWRHPTW45IL3NBJM76PZZD4GVCYV6RHQQ" />
     <recipe>
-      <copy-from dest="libexpat.dll" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" source="expat_1_95_1.dll"/>
+      <archive href="https://sourceforge.net/projects/expat/files/expat_win32/1.95.1/expat_win32bin_1_95_1.zip" size="119596" type="application/zip" extract="expat_win32bin_1_95_1" />
+      <rename source="expat_1_95_1.dll" dest="libexpat.dll" />
+    </recipe>
+    <recipe>
+      <archive href="https://github.com/libexpat/libexpat/releases/download/R_1_95_1/expat_win32bin_1_95_1.zip?raw=true" size="119596" type="application/zip" extract="expat_win32bin_1_95_1" />
+      <rename source="expat_1_95_1.dll" dest="libexpat.dll" />
     </recipe>
   </implementation>
 


### PR DESCRIPTION
add gentoo package and cross distro package names 
add gnuwin32 implementation

This is an alternative to #141 and its companion feed in https://github.com/0install/0install.de-feeds/pull/24

I don't prefer either option. @talex5 take your pick
Accept #141 to avoid having additional pull request reviews on this repository when new implementations of windows expat are added.
Accept this if that is a misunderstanding and the windows implementations should be in this repository.

support for https://github.com/0install/0install.de-feeds/issues/3