### PR TITLE
Pthread

### DIFF
--- a/lib/pthreads-win32.xml
+++ b/lib/pthreads-win32.xml
@@ -9,13 +9,13 @@ Win32 does not, and is unlikely to ever, support pthreads natively. This project
 </description>
   <category>Development</category>
   <homepage>http://www.sourceware.org/pthreads-win32</homepage>
-  <group arch="Windows-*" license="LGPL (GNU Lesser General Public License)">
+  <group arch="Windows-i486" license="LGPL (GNU Lesser General Public License)">
     <implementation version="1.11.0" released="2005-06-04" id="sha1new=bff2eaab145f4b3a18e24328aca2851a83b8c020">
       <manifest-digest sha256new="KCOC4C2RFLQBMWMZX6DFU4XZDM4W2WWQKFGKR6QYKVVA4FQ27OVA" />
       <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-1-11-0-release/lib/pthreadGC1.dll" size="60489" dest="pthreadGC.dll" />
     </implementation>
     <group version="2.9.1" released="2012-05-27">
-      <implementation arch="Windows-i386" id="sha1new=78219fee18e39cca9bc7019f195cd140978912e0">
+      <implementation id="sha1new=78219fee18e39cca9bc7019f195cd140978912e0">
         <manifest-digest sha256new="QR3ZQOYCQ2Q5MS6OV5CCLZP7IX3YNMAW7UIII2ZLCI46DNULR3NQ" />
         <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x86/pthreadGC2.dll" size="119888" dest="pthreadGC2.dll" />
       </implementation>

--- a/lib/pthreads-win32.xml
+++ b/lib/pthreads-win32.xml
@@ -13,15 +13,21 @@ Win32 does not, and is unlikely to ever, support pthreads natively. This project
     <implementation version="1.11.0" released="2005-06-04" id="sha1new=bff2eaab145f4b3a18e24328aca2851a83b8c020">
       <manifest-digest sha256new="KCOC4C2RFLQBMWMZX6DFU4XZDM4W2WWQKFGKR6QYKVVA4FQ27OVA" />
       <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-1-11-0-release/lib/pthreadGC1.dll" size="60489" dest="pthreadGC.dll" />
+      <file href="https://gcc.gnu.org/pub/pthreads-win32/prebuilt-dll-1-11-0-release/lib/pthreadGC1.dll" size="60489" dest="pthreadGC.dll" />
+      <file href="http://mirrors.kernel.org/sourceware/pthreads-win32/prebuilt-dll-1-11-0-release/lib/pthreadGC1.dll" size="60489" dest="pthreadGC.dll" />
     </implementation>
     <group version="2.9.1" released="2012-05-27">
       <implementation id="sha1new=78219fee18e39cca9bc7019f195cd140978912e0">
         <manifest-digest sha256new="QR3ZQOYCQ2Q5MS6OV5CCLZP7IX3YNMAW7UIII2ZLCI46DNULR3NQ" />
         <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x86/pthreadGC2.dll" size="119888" dest="pthreadGC2.dll" />
+        <file href="https://gcc.gnu.org/pub/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x86/pthreadGC2.dll" size="119888" dest="pthreadGC2.dll" />
+        <file href="http://mirrors.kernel.org/sourceware/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x86/pthreadGC2.dll" size="119888" dest="pthreadGC2.dll" />
       </implementation>
       <implementation arch="Windows-x86_64" id="sha1new=ef0dc69b66ffff057ed473404413e9cdf2900661">
         <manifest-digest sha256new="PL3W2VU5L6T2MXBZCBXESMRK7MZYQV27IU3DYX2UJANEMKCDNUHQ" />
         <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x64/pthreadGC2.dll" size="185976" dest="pthreadGC2.dll" />
+        <file href="https://gcc.gnu.org/pub/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x64/pthreadGC2.dll" size="185976" dest="pthreadGC2.dll" />
+        <file href="http://mirrors.kernel.org/sourceware/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x64/pthreadGC2.dll" size="185976" dest="pthreadGC2.dll" />
       </implementation>
     </group>
   </group>

--- a/lib/pthreads-win32.xml
+++ b/lib/pthreads-win32.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://repo.roscidus.com/lib/pthreads-win32" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>pthreads-win32</name>
+  <summary xml:lang="en">Open Source POSIX Threads for Win32</summary>
+  <description xml:lang="en">The POSIX 1003.1-2001 standard defines an application programming interface (API) for writing multithreaded applications. This interface is known more commonly as pthreads. A good number of modern operating systems include a threading library of some kind: Solaris (UI) threads, Win32 threads, DCE threads, DECthreads, or any of the draft revisions of the pthreads standard. The trend is that most of these systems are slowly adopting the pthreads standard API, with application developers following suit to reduce porting woes.  
+Win32 does not, and is unlikely to ever, support pthreads natively. This project seeks to provide a freely available and high-quality solution to this problem. 
+</description>
+  <category>Development</category>
+  <homepage>http://www.sourceware.org/pthreads-win32</homepage>
+  <implementation arch="Windows-*" id="sha1new=bff2eaab145f4b3a18e24328aca2851a83b8c020" license="LGPL (GNU Lesser General Public License)" released="2005-06-04" version="1.11.0">
+    <manifest-digest sha256new="KCOC4C2RFLQBMWMZX6DFU4XZDM4W2WWQKFGKR6QYKVVA4FQ27OVA"/>
+    <file dest="pthreadGC.dll" href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-1-11-0-release/lib/pthreadGC1.dll" size="60489"/>
+  </implementation>
+</interface>

--- a/lib/pthreads-win32.xml
+++ b/lib/pthreads-win32.xml
@@ -3,13 +3,26 @@
 <interface uri="http://repo.roscidus.com/lib/pthreads-win32" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
   <name>pthreads-win32</name>
   <summary xml:lang="en">Open Source POSIX Threads for Win32</summary>
-  <description xml:lang="en">The POSIX 1003.1-2001 standard defines an application programming interface (API) for writing multithreaded applications. This interface is known more commonly as pthreads. A good number of modern operating systems include a threading library of some kind: Solaris (UI) threads, Win32 threads, DCE threads, DECthreads, or any of the draft revisions of the pthreads standard. The trend is that most of these systems are slowly adopting the pthreads standard API, with application developers following suit to reduce porting woes.  
+  <description xml:lang="en">GNUC/not dependent on exceptions version
+The POSIX 1003.1-2001 standard defines an application programming interface (API) for writing multithreaded applications. This interface is known more commonly as pthreads. A good number of modern operating systems include a threading library of some kind: Solaris (UI) threads, Win32 threads, DCE threads, DECthreads, or any of the draft revisions of the pthreads standard. The trend is that most of these systems are slowly adopting the pthreads standard API, with application developers following suit to reduce porting woes.  
 Win32 does not, and is unlikely to ever, support pthreads natively. This project seeks to provide a freely available and high-quality solution to this problem. 
 </description>
   <category>Development</category>
   <homepage>http://www.sourceware.org/pthreads-win32</homepage>
-  <implementation arch="Windows-*" id="sha1new=bff2eaab145f4b3a18e24328aca2851a83b8c020" license="LGPL (GNU Lesser General Public License)" released="2005-06-04" version="1.11.0">
-    <manifest-digest sha256new="KCOC4C2RFLQBMWMZX6DFU4XZDM4W2WWQKFGKR6QYKVVA4FQ27OVA"/>
-    <file dest="pthreadGC.dll" href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-1-11-0-release/lib/pthreadGC1.dll" size="60489"/>
-  </implementation>
+  <group arch="Windows-*" license="LGPL (GNU Lesser General Public License)">
+    <implementation version="1.11.0" released="2005-06-04" id="sha1new=bff2eaab145f4b3a18e24328aca2851a83b8c020">
+      <manifest-digest sha256new="KCOC4C2RFLQBMWMZX6DFU4XZDM4W2WWQKFGKR6QYKVVA4FQ27OVA" />
+      <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-1-11-0-release/lib/pthreadGC1.dll" size="60489" dest="pthreadGC.dll" />
+    </implementation>
+    <group version="2.9.1" released="2012-05-27">
+      <implementation arch="Windows-i386" id="sha1new=78219fee18e39cca9bc7019f195cd140978912e0">
+        <manifest-digest sha256new="QR3ZQOYCQ2Q5MS6OV5CCLZP7IX3YNMAW7UIII2ZLCI46DNULR3NQ" />
+        <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x86/pthreadGC2.dll" size="119888" dest="pthreadGC2.dll" />
+      </implementation>
+      <implementation arch="Windows-x86_64" id="sha1new=ef0dc69b66ffff057ed473404413e9cdf2900661">
+        <manifest-digest sha256new="PL3W2VU5L6T2MXBZCBXESMRK7MZYQV27IU3DYX2UJANEMKCDNUHQ" />
+        <file href="ftp://sourceware.org/pub/pthreads-win32/prebuilt-dll-2-9-1-release/dll/x64/pthreadGC2.dll" size="185976" dest="pthreadGC2.dll" />
+      </implementation>
+    </group>
+  </group>
 </interface>


### PR DESCRIPTION
Add pthread-win32.
Needed as a dependency to gnuwin32 chess.
This is a windows only project. The project hasn't released since 2013. It seems pretty dead so 0watch and 0template not included.

There are variants for combinations of compiler (vc or gcc) and exception handling(longjump, c++, SEH) but this variant is the most commonly used according to the read-me.

There are no convenient archives for these binary distributions so I'm just pulling the dlll files

Support for https://github.com/0install/0install.de-feeds/issues/3