### PR TITLE
Added helm-autoversion

### DIFF
--- a/kubernetes/helm-autoversion.py
+++ b/kubernetes/helm-autoversion.py
@@ -1,0 +1,20 @@
+import sys
+import subprocess
+import re
+
+def helm(version, args):
+    return ['0install', 'run', '--version', version, 'http://repo.roscidus.com/kubernetes/helm'] + args
+
+def get_version():
+    version_dependant_commands = ['list', 'ls', 'get', 'status', 'history', 'hist', 'install', 'upgrade', 'test', 'rollback', 'delete', 'del']
+    if any(x in version_dependant_commands for x in sys.argv[1:]):
+        try:
+            process = subprocess.run(helm('..!3-pre', ['version', '--server']), check=True, stdout=subprocess.PIPE, universal_newlines=True)
+        except subprocess.CalledProcessError as ex:
+            sys.exit(ex.returncode)
+        result = re.search(r'SemVer:"v(?P<version>[^"]*)"', process.stdout)
+        if result:
+            return result.group('version')
+    return '..!3-pre'
+
+sys.exit(subprocess.call(helm(get_version(), sys.argv[1:])))

--- a/kubernetes/helm-autoversion.xml
+++ b/kubernetes/helm-autoversion.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/kubernetes/helm-autoversion" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Helm Autoversion</name>
+  <summary>wrapper for Helm that auto-downloads client matching server version</summary>
+  <description>A wrapper for Kubernetes Helm that automatically downloads a Helm (client) version that matches the Tiller (server) version.</description>
+  <needs-terminal/>
+
+  <!-- Intended to be registered by users via: 0install add-feed http://repo.roscidus.com/kubernetes/helm-autoversion -->
+  <feed-for interface="http://repo.roscidus.com/kubernetes/helm"/>
+
+  <!-- Marked as version 3-pre to be considered "better" than all Helm 2.x releases but not as a candidate for Helm >= 3.0. -->
+  <implementation license="MIT License" released="2019-07-16" stability="stable" id="sha1new=a551fc5839686a79ee5fe9b7412f0bcb82b43605" version="3-pre">
+    <manifest-digest sha256new="YK4PPBMOGQYPFR227KIBN3NCXBE3FM2FGY2NMOAAOX3R7N66RPUA"/>
+    <command name="run" path="helm-autoversion.py">
+      <runner interface="http://repo.roscidus.com/python/python"/>
+    </command>
+    <archive href="helm-autoversion.zip" size="1035" type="application/zip"/>
+  </implementation>
+
+</interface>


### PR DESCRIPTION
Helm Autoversion is a small Python wrapper for Kubernetes Helm that automatically downloads a Helm (client) version that matches the Tiller (server) version.

This PR requires [helm-autoversion.zip](https://github.com/0install/repo.roscidus.com/files/3395714/helm-autoversion.zip) to be placed in `incoming/`. This ZIP file contains the same `helm-autoversion.py` file that is also included in the PR for reference.

Suggested update for `kubernetes/index.html`:

```html
<!DOCTYPE html>
<html>
  <head>
    <title>repo.roscidus.com: Kubernetes</title>
  </head>
  <body>
    <h1>repo.roscidus.com: Kubernetes</h1>
    <p>
      Kubernetes is an open source system for managing containerized applications across multiple hosts.
    </p>

    <p>To add the Kubernetes client CLI to your <code>PATH</code>:</p>
    <pre>
      $ 0install add kubectl http://repo.roscidus.com/kubernetes/kubectl
    </pre>

    <p>To add additional common Kubernetes tools to your <code>PATH</code>:</p>
    <pre>
      $ 0install add minikube http://repo.roscidus.com/kubernetes/minikube
      $ 0install add helm http://repo.roscidus.com/kubernetes/helm
    </pre>

    <p>To make 0install automatically download a Helm (client) version that matches the Tiller (server) version:</p>
    <pre>
      $ 0install add helm http://repo.roscidus.com/kubernetes/helm-autoversion
    </pre>

    <p>To have 0install automatically pick Helm versions when pulled in as a dependency (e.g., from helmfile):</p>
    <pre>
      $ 0install add-feed http://repo.roscidus.com/kubernetes/helm-autoversion
    </pre>

    <h2>Official tools</h2>

    <ul>
      <li><a href='kubectl'>kubectl</a></li>
      <li><a href='minikube'>Minikube</a></li>
      <li><a href='helm'>Helm</a></li>
      <li><a href='kompose'>Kompose</a></li>
      <li><a href='kops'>kops</a></li>
      <li><a href='svcat'>svcat</a></li>
    </ul>

    <h2>3rd party tools</h2>

    <ul>
      <li><a href='helm-autoversion'>helm-autoversion</a></li>
      <li><a href='helmfile'>helmfile</a></li>
      <li><a href='k9s'>k9s</a></li>
    </ul>
  </body>
</html>
```