### PR TITLE
Added Octant

### DIFF
--- a/kubernetes/octant.watch.py
+++ b/kubernetes/octant.watch.py
@@ -1,0 +1,5 @@
+from urllib import request
+import json
+
+data = request.urlopen('https://api.github.com/repos/vmware/octant/releases').read().decode('utf-8')
+releases = [{'version': release['tag_name'].strip('v'), 'released': release['published_at'][0:10]} for release in json.loads(data)]

--- a/kubernetes/octant.xml
+++ b/kubernetes/octant.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<interface uri="http://repo.roscidus.com/kubernetes/octant" xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Octant</name>
+  <summary>web-based tool for visualizing Kubernetes clusters</summary>
+  <description>A web-based, highly extensible platform for developers to better understand the complexity of Kubernetes clusters.</description>
+  <homepage>https://github.com/vmware/octant</homepage>
+  <needs-terminal/>
+
+  <entry-point binary-name="octant" command="run"/>
+
+  <group license="Apache License 2.0">
+    <implementation arch="Windows-x86_64" id="sha1new=cb3d0b366de729d352bc095ea1b7d78626729b47" main="octant.exe" released="2019-07-19" stability="stable" version="0.4.0">
+      <manifest-digest sha256new="LAHO4KFDJZ2QAL5FQTKVYW4Z4NEPZNDQFVQDWGQQINXP2USJUNWQ"/>
+      <archive extract="octant_0.4.0_Windows-64bit" href="https://github.com/vmware/octant/releases/download/v0.4.0/octant_0.4.0_Windows-64bit.zip" size="21427875" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=0130a9c3d480eb10065394fd626ac347b1312be3" main="octant" released="2019-07-19" stability="stable" version="0.4.0">
+      <manifest-digest sha256new="2XSP5JAYCBLSB4JY2CPAX4VNNQEQ6DAXMTXYTOUW6O4V4YSJL2UQ"/>
+      <archive extract="octant_0.4.0_Linux-64bit" href="https://github.com/vmware/octant/releases/download/v0.4.0/octant_0.4.0_Linux-64bit.tar.gz" size="21405835" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-x86_64" id="sha1new=6191288dbb6b5e5e6857e4b19c2e5067fd1672db" main="octant" released="2019-07-19" stability="stable" version="0.4.0">
+      <manifest-digest sha256new="CWYKUAVYBQEPZUBEKV3F7BSPV7PMKFWTPYEV72YDACE3AX34T2FQ"/>
+      <archive extract="octant_0.4.0_macOS-64bit" href="https://github.com/vmware/octant/releases/download/v0.4.0/octant_0.4.0_macOS-64bit.tar.gz" size="21341569" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=8a0315e8d5e314c35d1c8c5125994e5c3678837e" main="octant.exe" released="2019-07-29" stability="stable" version="0.4.1">
+      <manifest-digest sha256new="ZFIFAJR5EU3FPOXGBONN27OPLKOLU7HCKYYXM62NLATF77NSP6HA"/>
+      <archive extract="octant_0.4.1_Windows-64bit" href="https://github.com/vmware/octant/releases/download/v0.4.1/octant_0.4.1_Windows-64bit.zip" size="22053777" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=18e3f3aea888b6c0ef57d0adfcd01c794864cdb8" main="octant" released="2019-07-29" stability="stable" version="0.4.1">
+      <manifest-digest sha256new="DLQKAHU6ML7GT6XT3HOBE5DWSQSNMAHG5X43Q6HWWIBUZWJQYF4A"/>
+      <archive extract="octant_0.4.1_Linux-64bit" href="https://github.com/vmware/octant/releases/download/v0.4.1/octant_0.4.1_Linux-64bit.tar.gz" size="22015778" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-x86_64" id="sha1new=9c96ff22b249e4b1fdb9ad38f0b92b88026e506c" main="octant" released="2019-07-29" stability="stable" version="0.4.1">
+      <manifest-digest sha256new="MUYWRXEVEXY6SE2KMLNHK7BADOGWPAJCT53JDMF2RIT3A2VKZ5RQ"/>
+      <archive extract="octant_0.4.1_macOS-64bit" href="https://github.com/vmware/octant/releases/download/v0.4.1/octant_0.4.1_macOS-64bit.tar.gz" size="21946991" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=cf61d06cc4c2990106329af2db55743f0dcc11a5" main="octant.exe" released="2019-08-05" stability="stable" version="0.5.0">
+      <manifest-digest sha256new="E5SJ6EZXDFFE2TDORUAOTKQRZDW4W725HFACG4PAJVSMTLLRGH7A"/>
+      <archive extract="octant_0.5.0_Windows-64bit" href="https://github.com/vmware/octant/releases/download/v0.5.0/octant_0.5.0_Windows-64bit.zip" size="22043697" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=294c63222753be656aded88eb952b5d983dbde97" main="octant" released="2019-08-05" stability="stable" version="0.5.0">
+      <manifest-digest sha256new="UHRXSFL747FKXFWWEBX36PRVL3XG5UMZNGMB45CEY7WEC6UY6YLQ"/>
+      <archive extract="octant_0.5.0_Linux-64bit" href="https://github.com/vmware/octant/releases/download/v0.5.0/octant_0.5.0_Linux-64bit.tar.gz" size="22011714" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-x86_64" id="sha1new=d1e512d06fb4b008de85b8ed112858f2398a9e4a" main="octant" released="2019-08-05" stability="stable" version="0.5.0">
+      <manifest-digest sha256new="RV5KEXUAVSIS5CZBX4HF7IIWHLJCHRC5AUCLRLR54OAXLULJYIDA"/>
+      <archive extract="octant_0.5.0_macOS-64bit" href="https://github.com/vmware/octant/releases/download/v0.5.0/octant_0.5.0_macOS-64bit.tar.gz" size="21955279" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="Windows-x86_64" id="sha1new=f47819e7f3d4eebe2e4c22c26ec6c746b8ce7934" main="octant.exe" released="2019-08-06" stability="stable" version="0.5.1">
+      <manifest-digest sha256new="B5Y5DGBY3C5C7RRQDYYJOT4J5SCMFE5UWNXIVZG7VVCKOBGRRHJA"/>
+      <archive extract="octant_0.5.1_Windows-64bit" href="https://github.com/vmware/octant/releases/download/v0.5.1/octant_0.5.1_Windows-64bit.zip" size="22045079" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" id="sha1new=4b2df81f9d3f1b53039ee50a637af0cf08b46369" main="octant" released="2019-08-06" stability="stable" version="0.5.1">
+      <manifest-digest sha256new="ROJVMDRKG5I7MEW2JZWTQLU66E3JRGI5EUYRI7JXHAKDRV6ZRFFQ"/>
+      <archive extract="octant_0.5.1_Linux-64bit" href="https://github.com/vmware/octant/releases/download/v0.5.1/octant_0.5.1_Linux-64bit.tar.gz" size="22011742" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-x86_64" id="sha1new=d909bd07cde6f4f89eca02fdaafed79af51f6219" main="octant" released="2019-08-06" stability="stable" version="0.5.1">
+      <manifest-digest sha256new="AVNUS2WBDOGQ7AENNFTCZKAUVSN7ZF6CUCPLE2PV37PJDAWTAEEQ"/>
+      <archive extract="octant_0.5.1_macOS-64bit" href="https://github.com/vmware/octant/releases/download/v0.5.1/octant_0.5.1_macOS-64bit.tar.gz" size="21955268" type="application/x-compressed-tar"/>
+    </implementation>
+  </group>
+</interface>

--- a/kubernetes/octant.xml.template
+++ b/kubernetes/octant.xml.template
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<interface xmlns="http://zero-install.sourceforge.net/2004/injector/interface">
+  <name>Octant</name>
+  <summary>web-based tool for visualizing Kubernetes clusters</summary>
+  <description>A web-based, highly extensible platform for developers to better understand the complexity of Kubernetes clusters.</description>
+  <homepage>https://github.com/vmware/octant</homepage>
+  <needs-terminal/>
+
+  <feed-for interface="http://repo.roscidus.com/kubernetes/octant"/>
+
+  <group license="Apache License 2.0">
+    <implementation arch="Windows-x86_64" main="octant.exe" released="{released}" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="octant_{version}_Windows-64bit" href="https://github.com/vmware/octant/releases/download/v{version}/octant_{version}_Windows-64bit.zip" type="application/zip"/>
+    </implementation>
+    <implementation arch="Linux-x86_64" main="octant" released="{released}" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="octant_{version}_Linux-64bit" href="https://github.com/vmware/octant/releases/download/v{version}/octant_{version}_Linux-64bit.tar.gz" type="application/x-compressed-tar"/>
+    </implementation>
+    <implementation arch="MacOSX-x86_64" main="octant" released="{released}" stability="stable" version="{version}">
+      <manifest-digest/>
+      <archive extract="octant_{version}_macOS-64bit" href="https://github.com/vmware/octant/releases/download/v{version}/octant_{version}_macOS-64bit.tar.gz" type="application/x-compressed-tar"/>
+    </implementation>
+  </group>
+</interface>


### PR DESCRIPTION
This adds a feed for Octant, a web-based tool for visualizing Kubernetes clusters.

Updated snippet for `kubernetes/index.html`:

```html
    <h2>3rd party tools</h2>

    <ul>
      <li><a href='helmfile'>helmfile</a></li>
      <li><a href='k9s'>k9s</a></li>
      <li><a href='octant'>Octant</a></li>
    </ul>
```