### PR TITLE
add gnuwin32 libpng packages

### DIFF
--- a/lib/png12-0.xml
+++ b/lib/png12-0.xml
@@ -8,12 +8,12 @@ PNG (Portable Network Graphics) format files.
 
 This package contains the runtime library files needed to run software
 using libpng.</description>
-  <homepage>http://gnuwin32.sourceforge.net/packages/libpng.htm</homepage>
+  <homepage>http://libpng.org/pub/png/libpng.html</homepage>
   <package-implementation package="libpng12-0"/>
   <package-implementation package="libpng12"/>
   <package-implementation distributions="Gentoo" package="media-libs/libpng"/>
   <package-implementation package="libpng"/>
-  <group arch="Windows-*" license="zlib/libpng License" >
+  <group arch="Windows-i486" license="zlib/libpng License" >
     <implementation id="sha1new=645d128ce5ce2854d46053aff867d19bd113d75a" released="2009-06-04" version="1.2.37-3">
       <requires interface="http://repo.roscidus.com/lib/zlib">
         <environment insert="bin" name="PATH"/>

--- a/lib/png12-0.xml
+++ b/lib/png12-0.xml
@@ -8,8 +8,35 @@ PNG (Portable Network Graphics) format files.
 
 This package contains the runtime library files needed to run software
 using libpng.</description>
+  <homepage>http://gnuwin32.sourceforge.net/packages/libpng.htm</homepage>
   <package-implementation package="libpng12-0"/>
   <package-implementation package="libpng12"/>
+  <package-implementation distributions="Gentoo" package="media-libs/libpng"/>
+  <package-implementation package="libpng"/>
+  <group arch="Windows-*" license="zlib/libpng License" >
+    <implementation id="sha1new=645d128ce5ce2854d46053aff867d19bd113d75a" released="2009-06-04" version="1.2.37-3">
+      <requires interface="https://gitlab.com/pmiess/0install-feeds/raw/test/public/gnuwin32/zlib.xml">
+        <environment insert="bin" name="PATH"/>
+      </requires>
+      <manifest-digest sha256new="OONNI4P2HTCILMPAHNV6EKFW46K6KKCT677OH75IUA2XPKQJKLNA"/>
+      <archive href="https://sourceforge.net/projects/gnuwin32/files/libpng/1.2.37/libpng-1.2.37-bin.zip" size="401037" type="application/zip"/>
+      <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/libpng-1.2.37-bin.zip?raw=true" size="401037" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=64767211e07d298a15caf66047f1e6cbcef96d29" released="2004-12-04" version="1.2.8-3">
+      <requires interface="https://gitlab.com/pmiess/0install-feeds/raw/test/public/gnuwin32/zlib.xml">
+        <environment insert="bin" name="PATH"/>
+      </requires>
+      <manifest-digest sha256new="D2CPLK7EGVRJFC42KVGNFPZSP6DHNOYWY2ZBA7B22AFNBNTCX5BQ"/>
+      <archive href="https://sourceforge.net/projects/gnuwin32/files/libpng/1.2.8/libpng-1.2.8-bin.zip" size="266839" type="application/zip"/>
+    </implementation>
+    <implementation id="sha1new=e081ab7912de52a62617feb678a72a085d0911b4" released="2004-09-19" version="1.2.7-3">
+      <requires interface="https://gitlab.com/pmiess/0install-feeds/raw/test/public/gnuwin32/zlib.xml">
+        <environment insert="bin" name="PATH"/>
+      </requires>
+      <manifest-digest sha256new="YMGEAXWP2U4B36A75TBRXJFQAO2QTSOYB6EF4QBUU447ETAX2LJQ"/>
+      <archive href="https://sourceforge.net/projects/gnuwin32/files/libpng/1.2.7/libpng-1.2.7-bin.zip" size="266940" type="application/zip"/>
+    </implementation>
+  </group>
   <group arch="Linux-i386">
     <implementation id="sha1new=c33007f8f0185af570fe3c37f391b5832c8cb2de" released="2011-10-01" version="1.2.44-1">
       <archive href="http://repo.roscidus.com/lib/png12-0/libpng12-0-i386-1.2.44-1+squeeze1.tar.bz2" size="106531"/>

--- a/lib/png12-0.xml
+++ b/lib/png12-0.xml
@@ -15,7 +15,7 @@ using libpng.</description>
   <package-implementation package="libpng"/>
   <group arch="Windows-*" license="zlib/libpng License" >
     <implementation id="sha1new=645d128ce5ce2854d46053aff867d19bd113d75a" released="2009-06-04" version="1.2.37-3">
-      <requires interface="https://gitlab.com/pmiess/0install-feeds/raw/test/public/gnuwin32/zlib.xml">
+      <requires interface="http://repo.roscidus.com/lib/zlib">
         <environment insert="bin" name="PATH"/>
       </requires>
       <manifest-digest sha256new="OONNI4P2HTCILMPAHNV6EKFW46K6KKCT677OH75IUA2XPKQJKLNA"/>
@@ -23,14 +23,14 @@ using libpng.</description>
       <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/libpng-1.2.37-bin.zip?raw=true" size="401037" type="application/zip"/>
     </implementation>
     <implementation id="sha1new=64767211e07d298a15caf66047f1e6cbcef96d29" released="2004-12-04" version="1.2.8-3">
-      <requires interface="https://gitlab.com/pmiess/0install-feeds/raw/test/public/gnuwin32/zlib.xml">
+      <requires interface="http://repo.roscidus.com/lib/zlib">
         <environment insert="bin" name="PATH"/>
       </requires>
       <manifest-digest sha256new="D2CPLK7EGVRJFC42KVGNFPZSP6DHNOYWY2ZBA7B22AFNBNTCX5BQ"/>
       <archive href="https://sourceforge.net/projects/gnuwin32/files/libpng/1.2.8/libpng-1.2.8-bin.zip" size="266839" type="application/zip"/>
     </implementation>
     <implementation id="sha1new=e081ab7912de52a62617feb678a72a085d0911b4" released="2004-09-19" version="1.2.7-3">
-      <requires interface="https://gitlab.com/pmiess/0install-feeds/raw/test/public/gnuwin32/zlib.xml">
+      <requires interface="http://repo.roscidus.com/lib/zlib">
         <environment insert="bin" name="PATH"/>
       </requires>
       <manifest-digest sha256new="YMGEAXWP2U4B36A75TBRXJFQAO2QTSOYB6EF4QBUU447ETAX2LJQ"/>


### PR DESCRIPTION
Add libpng packages from the gnuwin32 project.

This is a broadly supported library with 415 packages across 124 repositories in repology

Each of the 3 added versions is a dependency of a different one of the gnuwin32 packages
1.2.37
- libwmf
- piechart
- plotutils
- wv
- zimg

1.2.8
- gd 
- hp2xx
- netpbm
- tiff

1.2.5
- pngutils

this is part of https://github.com/0install/0install.de-feeds/issues/3
