### PR TITLE
add diffutils and its dependency regex

### DIFF
--- a/lib/regex.xml
+++ b/lib/regex.xml
@@ -12,7 +12,7 @@ Using the Regex library, you can:
 Regex provides three groups of functions with which you can operate on regular expressions. One group--the GNU group--is more powerful but not completely compatible with the other two, namely the POSIX and Berkeley UNIX groups; its interface was designed specifically for GNU. The other groups have the same interfaces as do the regular expression functions in POSIX and Berkeley UNIX. 
 </description>
   <homepage>http://www.gnu.org/directory/regex.html</homepage>
-  <implementation arch="Windows-*" id="sha1new=ccdcdaf83f133fdec116d6f35a76ab74734eaedf" license="LGPL (GNU Lesser General Public License)" released="2007-10-24" version="2.7">
+  <implementation arch="Windows-i486" id="sha1new=ccdcdaf83f133fdec116d6f35a76ab74734eaedf" license="LGPL (GNU Lesser General Public License)" released="2007-10-24" version="2.7">
     <manifest-digest sha256new="O6KGFCWKM7TWVCOYDZKZHS3Z66OAIPYR4KWYT6VDDM6C24V2IMGQ"/>
     <archive href="https://sourceforge.net/projects/gnuwin32/files/regex/2.7/regex-2.7-bin.zip" size="73283" type="application/zip"/>
     <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/regex-bin.zip?raw=true" size="73283" type="application/zip"/>

--- a/lib/regex.xml
+++ b/lib/regex.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://repo.roscidus.com/lib/regex" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Regex</name>
+  <summary xml:lang="en">Regex: searches for and matches text strings</summary>
+  <description xml:lang="en">A regular expression (or regexp, or pattern) is a text string that describes some set of strings. 
+
+Using the Regex library, you can: 
+•see if a string matches a specified pattern as a whole, and 
+•search within a string for a substring matching a specified pattern. 
+
+Regex provides three groups of functions with which you can operate on regular expressions. One group--the GNU group--is more powerful but not completely compatible with the other two, namely the POSIX and Berkeley UNIX groups; its interface was designed specifically for GNU. The other groups have the same interfaces as do the regular expression functions in POSIX and Berkeley UNIX. 
+</description>
+  <homepage>http://www.gnu.org/directory/regex.html</homepage>
+  <implementation arch="Windows-*" id="sha1new=ccdcdaf83f133fdec116d6f35a76ab74734eaedf" license="LGPL (GNU Lesser General Public License)" released="2007-10-24" version="2.7">
+    <manifest-digest sha256new="O6KGFCWKM7TWVCOYDZKZHS3Z66OAIPYR4KWYT6VDDM6C24V2IMGQ"/>
+    <archive href="https://sourceforge.net/projects/gnuwin32/files/regex/2.7/regex-2.7-bin.zip" size="73283" type="application/zip"/>
+    <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/regex-bin.zip?raw=true" size="73283" type="application/zip"/>
+  </implementation>
+</interface>

--- a/utils/diffutils.xml
+++ b/utils/diffutils.xml
@@ -16,7 +16,7 @@ You can use the sdiff command to merge two files interactively.
   <category>System</category>
   <homepage>http://gnuwin32.sourceforge.net/packages/diffutils.htm</homepage>
   <needs-terminal/>
-  <implementation arch="Windows-*" id="sha1new=b7ac58b6aac3d2e3e032305e667c5854818430be" langs="ca cs da de el es fi fr gl he hu id ja ms nl pl pt_BR ro ru sr sv tr zh_TW" license="GPL v2 (GNU General Public License)" released="2004-05-24" version="2.8.7-19-3">
+  <implementation arch="Windows-i486" id="sha1new=b7ac58b6aac3d2e3e032305e667c5854818430be" langs="ca cs da de el es fi fr gl he hu id ja ms nl pl pt_BR ro ru sr sv tr zh_TW" license="GPL v2 (GNU General Public License)" released="2004-05-24" version="2.8.7-19-3">
     <requires interface="http://repo.roscidus.com/devel/gettext">
       <environment insert="bin" name="PATH"/>
     </requires>

--- a/utils/diffutils.xml
+++ b/utils/diffutils.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://repo.roscidus.com/utils/diffutils" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>DiffUtils</name>
+  <summary xml:lang="en">show differences between files</summary>
+  <description xml:lang="en">You can use the diff command to show differences between two files, or each corresponding file in two directories. diff outputs differences between files line by line in any of several formats, selectable by command line options. This set of differences is often called a `diff' or `patch'. For files that are identical, diff normally produces no output; for binary (non-text) files, diff normally reports only that they are different. 
+
+You can use the cmp command to show the offsets and line numbers where two files differ. cmp can also show all the characters that differ between the two files, side by side. 
+
+You can use the diff3 command to show differences among three files. When two people have made independent changes to a common original, diff3 can report the differences between the original and the two changed versions, and can produce a merged file that contains both persons' changes together with warnings about conflicts. 
+
+You can use the sdiff command to merge two files interactively. 
+</description>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.ico" type="image/vnd.microsoft.icon"/>
+  <icon href="https://raw.githubusercontent.com/0install/0install.de-feeds/master/Gow.png" type="image/png"/>
+  <category>System</category>
+  <homepage>http://gnuwin32.sourceforge.net/packages/diffutils.htm</homepage>
+  <needs-terminal/>
+  <implementation arch="Windows-*" id="sha1new=b7ac58b6aac3d2e3e032305e667c5854818430be" langs="ca cs da de el es fi fr gl he hu id ja ms nl pl pt_BR ro ru sr sv tr zh_TW" license="GPL v2 (GNU General Public License)" released="2004-05-24" version="2.8.7-19-3">
+    <requires interface="http://repo.roscidus.com/devel/gettext">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="http://repo.roscidus.com/lib/libiconv">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <requires interface="http://repo.roscidus.com/lib/regex">
+      <environment insert="bin" name="PATH"/>
+    </requires>
+    <command name="run" path="bin/diff.exe"/>
+    <command name="cmp" path="bin/cmp.exe"/>
+    <command name="diff3" path="bin/diff3.exe"/>
+    <command name="sdiff" path="bin/sdiff.exe"/>
+    <manifest-digest sha256new="WTRKK7HJ6J5VU5MZZ3O5JRJ3MCHDTG6WVBJ36Z4JRAAKMQJDW5TQ"/>
+    <archive href="https://sourceforge.net/projects/gnuwin32/files/diffutils/2.8.7-1/diffutils-2.8.7-1-bin.zip" size="456027" type="application/zip"/>
+    <archive href="https://github.com/kkeybbs/gnuwin32/blob/master/gnuwin32/diffutils-bin.zip?raw=true" size="456027" type="application/zip"/>
+  </implementation>
+  <package-implementation distributions="Gentoo" package="sys-apps/diffutils"/>
+  <package-implementation package="diffutils"/>
+  <entry-point binary-name="diff" command="run">
+    <needs-terminal/>
+    <name xml:lang="en">Diff</name>
+    <summary xml:lang="en">Diff: find differences between two files</summary>
+    <description xml:lang="en">In  the simplest case, diff compares the contents of the
+       two files from-file and  to-file.   A  file  name  of  -
+       stands for text read from the standard input.  As a spe-
+       cial case, diff - - compares a copy of standard input to
+       itself.</description>
+  </entry-point>
+  <entry-point binary-name="cmp" command="cmp">
+    <needs-terminal/>
+    <name xml:lang="en">Cmp</name>
+    <summary xml:lang="en">Cmp: compare two files byte by byte</summary>
+    <description xml:lang="en">Compare two files byte by byte.</description>
+  </entry-point>
+  <entry-point binary-name="diff3" command="diff3">
+    <needs-terminal/>
+    <name xml:lang="en">Diff3</name>
+    <summary xml:lang="en">Diff3: compare three files line by line</summary>
+    <description xml:lang="en">Compare three files line by line.</description>
+  </entry-point>
+  <entry-point binary-name="sdiff" command="sdiff">
+    <needs-terminal/>
+    <name xml:lang="en">Sdiff</name>
+    <summary xml:lang="en">Sdiff: side-by-side merge of file differences</summary>
+    <description xml:lang="en">Side-by-side merge of file differences.</description>
+  </entry-point>
+</interface>


### PR DESCRIPTION
Add the gnuwin32 package for diffutils and its dependency regex.

diffutils is a broadly supported package with 150 packages across 120 repositories

diffutils is a dependency of the following gnuwin32 packages

-   a2ps
-   bzip2
-   groff
-   gzip
-   sharutils

regex is a dependency of the following gnuwin32 packages

-   bison
-   diction
-   diffutils
-   ed
-   file
-   grep
-   m4
-   sed


This is part of https://github.com/0install/0install.de-feeds/issues/3