### PR TITLE
bdeps use i486

### DIFF
--- a/lib/expat1.xml
+++ b/lib/expat1.xml
@@ -23,7 +23,7 @@ parsing XML.</description>
       <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-amd64-2.0.1-7.tar.bz2" size="106257"/>
     </implementation>
   </group>
-  <implementation arch="Windows-*" version="1.95.0" released="2000-10-22" license="MIT/X Consortium License" id="1.95.1withdllrenamed">
+  <implementation arch="Windows-i486" version="1.95.0" released="2000-10-22" license="MIT/X Consortium License" id="1.95.1withdllrenamed">
     <manifest-digest sha256new="NIFBMKJZ277BARKR4SOXWRHPTW45IL3NBJM76PZZD4GVCYV6RHQQ" />
     <recipe>
       <archive href="https://sourceforge.net/projects/expat/files/expat_win32/1.95.1/expat_win32bin_1_95_1.zip" size="119596" type="application/zip" extract="expat_win32bin_1_95_1" />

--- a/lib/netcdf.xml
+++ b/lib/netcdf.xml
@@ -7,7 +7,7 @@
   <category>Science</category>
   <homepage>https://www.unidata.ucar.edu/software/netcdf/</homepage>
   <needs-terminal/>
-  <implementation arch="Windows-*" id="sha1new=b00607b01dd1d84ff10048ecbf6badd5deb937b8" license="UCAR-Unidata" released="2010-07-12" version="4.1.1">
+  <implementation arch="Windows-i486" id="sha1new=b00607b01dd1d84ff10048ecbf6badd5deb937b8" license="UCAR-Unidata" released="2010-07-12" version="4.1.1">
     <command name="run" path="ncdump.exe"/>
     <command name="ncgen" path="ncgen.exe"/>
     <command name="test" path="nf_test/run_tests.bat"/>

--- a/lib/readline4.xml
+++ b/lib/readline4.xml
@@ -9,7 +9,7 @@
   <category>System</category>
   <homepage>http://mingwrep.sourceforge.net/</homepage>
   <needs-terminal/>
-  <implementation arch="Windows-*" id="sha1new=cc673e7a4960169c3cae331701247a60a05b781a" license="GPL v2 (GNU General Public License)" released="2001-07-27" version="4.2-20010727">
+  <implementation arch="Windows-i486" id="sha1new=cc673e7a4960169c3cae331701247a60a05b781a" license="GPL v2 (GNU General Public License)" released="2001-07-27" version="4.2-20010727">
     <command name="run" path="bin/rl.exe"/>
     <command name="rlversion" path="bin/rlversion.exe"/>
     <manifest-digest sha256new="2MXPRT36XXCPZK54IV3HM6YGMUMB3IGNJFK4RX7RYNRSF6AZOM4Q"/>


### PR DESCRIPTION
Based on comments on other pull requests these feeds should be marked as i486 since they are binary dependencies