### PR TITLE
Use archives.db for all archives

### DIFF
--- a/devel/glade.xml
+++ b/devel/glade.xml
@@ -26,7 +26,7 @@ languages including C, C++, C#, Vala, Java, Perl, Python,and others.</descriptio
 	</compile:implementation>
       </command>
       <implementation id="sha1new=004cb5d03e788ef8e893e6c53ea3a4b56f432322" released="2012-07-08" version="3.8.2">
-	<archive extract="glade3-3.8.2" href="http://repo.roscidus.com/devel/glade/glade3-3.8.2-tal.tar.bz2" size="2739051" type="application/x-bzip-compressed-tar"/>
+	<archive extract="glade3-3.8.2" href="glade3-3.8.2-tal.tar.bz2" size="2739051" type="application/x-bzip-compressed-tar"/>
       </implementation>
     </group>
 
@@ -34,7 +34,7 @@ languages including C, C++, C#, Vala, Java, Perl, Python,and others.</descriptio
       <implementation id="sha1new=4d4909806e707060c207c9b5983bffc8b0179a4c" main="bin/glade-3" released="2012-07-08" version="3.8.2">
 	<environment insert="lib" name="LD_LIBRARY_PATH"/><environment insert="." mode="replace" name="GLADE_HOME"/>
 	<manifest-digest sha256="f80ae33b9ae3f551ef85871864d8b114381a9abda0aa5848068835783893cf24"/>
-	<archive extract="glade-linux-x86_64-3.8.2" href="http://repo.roscidus.com/devel/glade/glade-linux-x86_64-3.8.2.tar.bz2" size="3080690"/>
+	<archive extract="glade-linux-x86_64-3.8.2" href="glade-linux-x86_64-3.8.2.tar.bz2" size="3080690"/>
       </implementation>
     </group>
   </group>

--- a/devel/make.xml
+++ b/devel/make.xml
@@ -18,16 +18,16 @@ the Debian Free Software Guidelines, and has been removed from this package.</de
   <package-implementation distributions="MacPorts" main="/opt/local/bin/gmake" package="gmake"/>
   <group arch="Linux-i386" license="GPL v2 (GNU General Public License)" main="bin/make">
     <implementation id="sha1new=78fd81f1743ffe1c29f1025d1898b48634a391be" released="2010-04-25" version="3.81-5">
-      <archive href="http://repo.roscidus.com/devel/make/make-i386-3.81-5.tar.bz2" size="317167"/>
+      <archive href="make-i386-3.81-5.tar.bz2" size="317167"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=fdc117f803c22a910e10b03caf43bd08efedc475" released="2010-04-25" version="3.81-5">
-      <archive href="http://repo.roscidus.com/devel/make/make-amd64-3.81-5.tar.bz2" size="327457"/>
+      <archive href="make-amd64-3.81-5.tar.bz2" size="327457"/>
     </implementation>
     <implementation id="sha1new=62aea41d2b6ecfbb1569f739d607a7f664e73b81" released="2011-05-29" version="3.81-8">
-      <archive href="http://repo.roscidus.com/devel/make/make-i386-3.81-8.tar.bz2" size="320143"/>
+      <archive href="make-i386-3.81-8.tar.bz2" size="320143"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=cfdba304764c3265a3e35db5abc0e3bf170048e2" released="2011-05-29" version="3.81-8">
-      <archive href="http://repo.roscidus.com/devel/make/make-amd64-3.81-8.tar.bz2" size="330847"/>
+      <archive href="make-amd64-3.81-8.tar.bz2" size="330847"/>
     </implementation>
     <group arch="Windows-i486" license="GPL v2 (GNU General Public License)" main="bin/make.exe">
       <requires interface="http://repo.roscidus.com/devel/make-dep">

--- a/devel/pkg-config.xml
+++ b/devel/pkg-config.xml
@@ -22,18 +22,18 @@ and linker flags needed to use them through the pkg-config(1) program.</descript
     </requires>
     <group arch="Linux-i386">
       <implementation id="sha1new=7619ff7ef124c2dcc423be77d22c4d6deac30cab" main="bin/pkg-config" released="2010-04-24" version="0.22-1">
-        <archive href="http://repo.roscidus.com/devel/pkg-config/pkg-config-i386-0.22-1.tar.bz2" size="52359"/>
+        <archive href="pkg-config-i386-0.22-1.tar.bz2" size="52359"/>
       </implementation>
       <implementation id="sha1new=ac17f4bffd491781e31dbef628e0d0bf94d596d3" main="bin/pkg-config" released="2011-05-29" version="0.25-1.1">
-      <archive href="http://repo.roscidus.com/devel/pkg-config/pkg-config-i386-0.25-1.1.tar.bz2" size="57194"/>
+      <archive href="pkg-config-i386-0.25-1.1.tar.bz2" size="57194"/>
     </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=221455243b97d96b3db60220482cde5705c2196f" main="bin/pkg-config" released="2011-05-29" version="0.25-1.1">
-      <archive href="http://repo.roscidus.com/devel/pkg-config/pkg-config-amd64-0.25-1.1.tar.bz2" size="59401"/>
+      <archive href="pkg-config-amd64-0.25-1.1.tar.bz2" size="59401"/>
     </implementation>
     </group>
     <group arch="Linux-x86_64">
       <implementation id="sha1new=3f38637717d69aae67a7d0f843b239bb661a908f" main="bin/pkg-config" released="2010-04-24" version="0.22-1">
-        <archive href="http://repo.roscidus.com/devel/pkg-config/pkg-config-amd64-0.22-1.tar.bz2" size="55581"/>
+        <archive href="pkg-config-amd64-0.22-1.tar.bz2" size="55581"/>
       </implementation>
     </group>
   </group>

--- a/e/e-core.xml
+++ b/e/e-core.xml
@@ -13,19 +13,19 @@ E is a scripting language designed for writing secure distributed programs.</des
       <environment insert="bin/" mode="replace" name="RUNE_JRE_BIN"/>
     </requires>
     <implementation id="sha1new=d0ecc18c74a4342bf2a08da8237aee11d9f32b27" released="2009-12-30" stability="stable" version="0.9.2-post1">
-      <archive href="http://repo.roscidus.com/e/e-core/E-core-0.9.2-post1.tar.bz2" size="2933851" type="application/x-bzip-compressed-tar"/>
+      <archive href="E-core-0.9.2-post1.tar.bz2" size="2933851" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation id="sha1new=304c4433219b85bc7ebf7bc1d506ff2bc95aadb3" released="2010-03-31" stability="stable" version="0.9.2-post2">
-      <archive href="http://repo.roscidus.com/e/e-core/E-core-0.9.2-post2.tar.bz2" size="2946251" type="application/x-bzip-compressed-tar"/>
+      <archive href="E-core-0.9.2-post2.tar.bz2" size="2946251" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation id="sha1new=5bf4baf19514dac7964cf93f58a9345b055c8480" released="2010-06-07" stability="stable" version="0.9.2-post3">
-      <archive href="http://repo.roscidus.com/e/e-core/E-core-0.9.2-post3.tar.bz2" size="2953203" type="application/x-bzip-compressed-tar"/>
+      <archive href="E-core-0.9.2-post3.tar.bz2" size="2953203" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation id="sha1new=a2f045b8271eb21c9355bd7622ec459b1f33af89" released="2010-09-06" stability="stable" version="0.9.2-post4">
-      <archive href="http://repo.roscidus.com/e/e-core/E-core-0.9.2-post4.tar.bz2" size="2967153" type="application/x-bzip-compressed-tar"/>
+      <archive href="E-core-0.9.2-post4.tar.bz2" size="2967153" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation id="sha1new=c2a159f954ef928036dc7095b945b96bb02faba3" released="2010-11-20" version="0.9.2-post5">
-      <archive href="http://repo.roscidus.com/e/e-core/E-core-0.9.2-post5.tar.bz2" size="2967270" type="application/x-bzip-compressed-tar"/>
+      <archive href="E-core-0.9.2-post5.tar.bz2" size="2967270" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation id="sha1new=489654cfd0f86baaf3223c77418b2e3427255731" released="2011-01-06" stability="stable" version="0.9.3-4">
       <archive href="http://erights.org/download/0-9-3/E-purej-0.9.3d.tar.gz" size="3318378" type="application/x-compressed-tar"/>
@@ -92,7 +92,7 @@ E is a scripting language designed for writing secure distributed programs.</des
     </command>
     <implementation arch="*-src" id="sha1new=c481fecc0ca97b41ed4e827e23808ddedee7d7d9" released="2011-10-26" stability="stable" version="0.9.3-4-1">
       <manifest-digest sha256="373e56f54ca77a3491400c2e8be1ab02c761eb3fd76c17383178936abac737a4"/>
-      <archive extract="e-core-0.9.3-4-1" href="http://repo.roscidus.com/e/e-core/e-core-0.9.3-4-1.tar.bz2" size="15531961"/>
+      <archive extract="e-core-0.9.3-4-1" href="e-core-0.9.3-4-1.tar.bz2" size="15531961"/>
     </implementation>
   </group>
   <group>
@@ -111,7 +111,7 @@ E is a scripting language designed for writing secure distributed programs.</des
     </requires>
     <implementation id="sha1new=2079b36d1baa7892b57afa8623d7e540cdc0fbde" main="rune" released="2011-10-26" stability="stable" version="0.9.3-4-1">
       <manifest-digest sha256="c207743b915f17baadda01d0f7afc5318ff27f326448805c7bcf375f9f5de93e"/>
-      <archive extract="e-core-bin-0.9.3-4-1" href="http://repo.roscidus.com/e/e-core/e-core-bin-0.9.3-4-1.tar.bz2" size="3298954"/>
+      <archive extract="e-core-bin-0.9.3-4-1" href="e-core-bin-0.9.3-4-1.tar.bz2" size="3298954"/>
     </implementation>
   </group>
 </interface>

--- a/e/e-swt.xml
+++ b/e/e-swt.xml
@@ -9,7 +9,7 @@ package adds support for using it with the SWT widget set.</description>
   <homepage>http://erights.org</homepage>
   <category>Development</category>
   <implementation id="sha1new=58ee48b5da1c86990c0392795916f8ac7dd4cf4f" license="Public Domain" main="rune" released="2009-12-31" version="1.0">
-    <archive extract="e-swt" href="http://repo.roscidus.com/e/e-swt/e-swt.tar.bz2" size="222" type="application/x-bzip-compressed-tar"/>
+    <archive extract="e-swt" href="e-swt.tar.bz2" size="222" type="application/x-bzip-compressed-tar"/>
     <requires interface="http://repo.roscidus.com/e/e-core">
       <environment insert="rune" mode="replace" name="RUNE_BINARY"/>
     </requires>

--- a/games/openttd.xml
+++ b/games/openttd.xml
@@ -26,23 +26,23 @@ the original game as closely as possible while extending it with new features.</
       </requires>
       
       <implementation arch="Linux-i686" id="sha1new=19bf56c253e576baebc52f58e1df4bd74ef8c8d4" released="2010-06-12" stability="stable" version="1.0.1">
-	<archive extract="openttd-1.0.1-linux-i686" href="http://repo.roscidus.com/games/openttd/openttd-1.0.1-linux-i686.tar.bz2" size="17248708" type="application/x-bzip-compressed-tar"/>
+	<archive extract="openttd-1.0.1-linux-i686" href="openttd-1.0.1-linux-i686.tar.bz2" size="17248708" type="application/x-bzip-compressed-tar"/>
       </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=4611e563d76a7277784fd814a80fee0993803cac" released="2010-06-12" stability="stable" version="1.0.1">
-	<archive extract="openttd-1.0.1-linux-amd64" href="http://repo.roscidus.com/games/openttd/openttd-1.0.1-linux-amd64.tar.bz2" size="17443765" type="application/x-bzip-compressed-tar"/>
+	<archive extract="openttd-1.0.1-linux-amd64" href="openttd-1.0.1-linux-amd64.tar.bz2" size="17443765" type="application/x-bzip-compressed-tar"/>
       </implementation>
 
       <implementation arch="Linux-i686" id="sha1new=fc4f4ca517d9c743a9c48f103f9d9c3d0ae93479" released="2013-02-23" stability="stable" version="1.2.3">
-	<archive extract="openttd-1.2.3-linux-generic-i686" href="http://repo.roscidus.com/games/openttd/openttd-1.2.3-linux-generic-i686.tar.bz2" size="23705300" type="application/x-bzip-compressed-tar"/>
+	<archive extract="openttd-1.2.3-linux-generic-i686" href="openttd-1.2.3-linux-generic-i686.tar.bz2" size="23705300" type="application/x-bzip-compressed-tar"/>
       </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=060e25f6b624ed6d6ec20288638d6e7489850f2a" released="2013-02-23" stability="stable" version="1.2.3">
-	<archive extract="openttd-1.2.3-linux-generic-amd64" href="http://repo.roscidus.com/games/openttd/openttd-1.2.3-linux-generic-amd64.tar.bz2" size="23946059" type="application/x-bzip-compressed-tar"/>
+	<archive extract="openttd-1.2.3-linux-generic-amd64" href="openttd-1.2.3-linux-generic-amd64.tar.bz2" size="23946059" type="application/x-bzip-compressed-tar"/>
       </implementation>
     </group>
 
     <group arch="MacOSX-*" main="OpenTTD.app/Contents/MacOS/openttd">
       <implementation id="sha1new=3feff4b90b3ad5eac399937625bed34a83677f58" released="2013-02-23" stability="stable" version="1.2.3">
-	<archive extract="openttd-1.2.3-macosx-universal" href="http://repo.roscidus.com/games/openttd/openttd-1.2.3-macosx-universal.tar.bz2" size="23014669" type="application/x-bzip-compressed-tar"/>
+	<archive extract="openttd-1.2.3-macosx-universal" href="openttd-1.2.3-macosx-universal.tar.bz2" size="23014669" type="application/x-bzip-compressed-tar"/>
       </implementation>
     </group>
   </group>

--- a/git/core.xml
+++ b/git/core.xml
@@ -33,10 +33,10 @@ provided as separate git* packages.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=4ec5c577aab003f0f5e3a7728061a5def17176a8" main="usr/bin/git" released="2010-04-04" version="1.5.6.5-3">
-      <archive href="http://repo.roscidus.com/git/core/git-core-i386-1_1.5.6.5-3+lenny3.tar.bz2" size="2297187"/>
+      <archive href="git-core-i386-1_1.5.6.5-3+lenny3.tar.bz2" size="2297187"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=6f5d6acc5b9736ff757e7bda820806f0fc52e01b" main="usr/bin/git" released="2010-04-04" version="1.5.6.5-3">
-      <archive href="http://repo.roscidus.com/git/core/git-core-amd64-1_1.5.6.5-3+lenny3.tar.bz2" size="2512585"/>
+      <archive href="git-core-amd64-1_1.5.6.5-3+lenny3.tar.bz2" size="2512585"/>
     </implementation>
   </group>
   <group>
@@ -47,26 +47,26 @@ provided as separate git* packages.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=c89043aa88c264e0d38186133f1402ccaae2eb88" main="usr/bin/git" released="2011-05-29" version="1.7.2.5-1">
-      <archive href="http://repo.roscidus.com/git/core/git-i386-1_1.7.2.5-1.tar.bz2" size="3920091"/>
+      <archive href="git-i386-1_1.7.2.5-1.tar.bz2" size="3920091"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=2aa4e2d7a3a832bdee632bc65e13119b602bdb54" main="usr/bin/git" released="2011-05-29" version="1.7.2.5-1">
-      <archive href="http://repo.roscidus.com/git/core/git-amd64-1_1.7.2.5-1.tar.bz2" size="4438520"/>
+      <archive href="git-amd64-1_1.7.2.5-1.tar.bz2" size="4438520"/>
     </implementation>
     <implementation arch="Linux-i386" id="sha1new=edfee8eb96ce0096b5ad2279c5d1c79be5d95856" main="usr/bin/git" released="2011-09-17" version="1.7.2.5-2">
-      <archive href="http://repo.roscidus.com/git/core/git-i386-1_1.7.2.5-2.tar.bz2" size="3920349"/>
+      <archive href="git-i386-1_1.7.2.5-2.tar.bz2" size="3920349"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=dd3a3e7b45a695cf9997303151a49c8118912904" main="usr/bin/git" released="2011-09-17" version="1.7.2.5-2">
-      <archive href="http://repo.roscidus.com/git/core/git-amd64-1_1.7.2.5-2.tar.bz2" size="4438560"/>
+      <archive href="git-amd64-1_1.7.2.5-2.tar.bz2" size="4438560"/>
     </implementation>
     <group>
       <requires interface="http://repo.roscidus.com/lib/zlib1g">
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
       <implementation arch="Linux-i386" id="sha1new=d3b355aa19b2cebf7d6d4f7b090d20ec66abc920" main="usr/bin/git" released="2012-03-27" version="1.7.2.5-3">
-      <archive href="http://repo.roscidus.com/git/core/git-i386-1_1.7.2.5-3.tar.bz2" size="3921640"/>
+      <archive href="git-i386-1_1.7.2.5-3.tar.bz2" size="3921640"/>
     </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=886961d0c4b894d2fae2c7209577fb617b40bfef" main="usr/bin/git" released="2012-03-27" version="1.7.2.5-3">
-      <archive href="http://repo.roscidus.com/git/core/git-amd64-1_1.7.2.5-3.tar.bz2" size="4440339"/>
+      <archive href="git-amd64-1_1.7.2.5-3.tar.bz2" size="4440339"/>
     </implementation>
     </group>
   </group>

--- a/java/hsqldb.xml
+++ b/java/hsqldb.xml
@@ -13,6 +13,6 @@ tools.</description>
   <homepage>http://hsqldb.org/</homepage>
   <implementation id="sha1new=4ddf5a731e08856bb81b94a19f82448e493b315b" released="2010-02-07" version="2.0.0-rc8">
     <manifest-digest sha256="0434f6bc5e24bca516805d0b68cd202d0c20d570820684c1f87c5010803871a6"/>
-    <archive extract="hsqldb" href="http://repo.roscidus.com/java/hsqldb/hsqldb-bin-2.0.0-rc8.tar.bz2" size="1626331"/>
+    <archive extract="hsqldb" href="hsqldb-bin-2.0.0-rc8.tar.bz2" size="1626331"/>
   </implementation>
 </interface>

--- a/java/openjdk-6-jdk.xml
+++ b/java/openjdk-6-jdk.xml
@@ -35,10 +35,10 @@ IcedTea project.</description>
       </requires>
       <environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
       <implementation id="sha1new=6b2afc4b5841dfa24b996b321d08b48109b0c5c3" released="2011-05-29" version="6.18-1.8.7-2">
-	<archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b18-1.8.7-2~squeeze1-1.tar.bz2" size="8887727" type="application/x-bzip-compressed-tar"/>
+	<archive extract="java-6-openjdk" href="openjdk-6-jdk-6b18-1.8.7-2~squeeze1-1.tar.bz2" size="8887727" type="application/x-bzip-compressed-tar"/>
       </implementation>
       <implementation id="sha1new=9af7ae7fa806798b1df663c19cddf97f2aa411ca" released="2009-12-28" version="6.11" version-modifier="-9.1-1">
-	<archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2-1.tar.bz2" size="7610012" type="application/x-bzip-compressed-tar"/>
+	<archive extract="java-6-openjdk" href="openjdk-6-jdk-6b11-9.1+lenny2-1.tar.bz2" size="7610012" type="application/x-bzip-compressed-tar"/>
       </implementation>
     </group>
 
@@ -47,7 +47,7 @@ IcedTea project.</description>
 	<environment insert="bin/java" mode="replace" name="OPENJDK_JRE_JAVA"/>
       </requires>
       <implementation id="sha1new=f2da5d5538d0e3b9d9c0843cb9362e900fd33566" released="2009-12-27" version="6.11-9.1">
-	<archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2.tar.bz2" size="7602552" type="application/x-bzip-compressed-tar"/>
+	<archive extract="java-6-openjdk" href="openjdk-6-jdk-6b11-9.1+lenny2.tar.bz2" size="7602552" type="application/x-bzip-compressed-tar"/>
 	<environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
       </implementation>
     </group>

--- a/java/openjdk-6-jre.xml
+++ b/java/openjdk-6-jre.xml
@@ -16,19 +16,19 @@
   <group main="bin/java">
     <group arch="Linux-i386">
       <implementation id="sha1new=6b7c9f98bd1d8bec5bbb5ddb41271c862c8e8529" released="2011-05-29" version="6.18-1.8.7-2">
-	<archive extract="jre" href="http://repo.roscidus.com/java/openjdk-6-jre/openjdk-6-jre-6b18-1.8.7-2~squeeze1_6b18-1.8.7-2~squeeze1_1.7R2-4_6b18-1.8.7-2~squeeze1_1.26.2-5_2011c-0squeeze1_1.26.2-5-i386.tar.bz2" size="29764021" type="application/x-bzip-compressed-tar"/>
+	<archive extract="jre" href="openjdk-6-jre-6b18-1.8.7-2~squeeze1_6b18-1.8.7-2~squeeze1_1.7R2-4_6b18-1.8.7-2~squeeze1_1.26.2-5_2011c-0squeeze1_1.26.2-5-i386.tar.bz2" size="29764021" type="application/x-bzip-compressed-tar"/>
       </implementation>
       <implementation id="sha1new=6cc9f66b968d983904bce5050b2e328c3740462b" released="2009-12-08" version="6.11" version-modifier="-9.1-2">
-	<archive extract="jre" href="http://repo.roscidus.com/java/openjdk-6-jre/openjdk-6-jre-6b11-9.1+lenny2_6b11-9.1+lenny2_1.7R1-2_6b11-9.1+lenny2_1.23.0-3-i386.tar.bz2" size="26538063" type="application/x-bzip-compressed-tar"/>
+	<archive extract="jre" href="openjdk-6-jre-6b11-9.1+lenny2_6b11-9.1+lenny2_1.7R1-2_6b11-9.1+lenny2_1.23.0-3-i386.tar.bz2" size="26538063" type="application/x-bzip-compressed-tar"/>
       </implementation>
     </group>
     <group arch="Linux-x86_64">
       <implementation id="sha1new=3ede8dc4b83dd3d7705ee3a427b637a2cb98d789" released="2011-05-29" version="6.18-1.8.7-2">
-	<archive extract="jre" href="http://repo.roscidus.com/java/openjdk-6-jre/openjdk-6-jre-6b18-1.8.7-2~squeeze1_6b18-1.8.7-2~squeeze1_1.7R2-4_6b18-1.8.7-2~squeeze1_1.26.2-5_2011c-0squeeze1_1.26.2-5-amd64.tar.bz2" size="28281120" type="application/x-bzip-compressed-tar"/>
+	<archive extract="jre" href="openjdk-6-jre-6b18-1.8.7-2~squeeze1_6b18-1.8.7-2~squeeze1_1.7R2-4_6b18-1.8.7-2~squeeze1_1.26.2-5_2011c-0squeeze1_1.26.2-5-amd64.tar.bz2" size="28281120" type="application/x-bzip-compressed-tar"/>
       </implementation>
 
       <implementation id="sha1new=042663897b1fce617d5bc8c98945adc64e4ef2a9" released="2009-12-08" version="6.11-9.1-2">
-	<archive extract="jre" href="http://repo.roscidus.com/java/openjdk-6-jre/openjdk-6-jre-6b11-9.1+lenny2_6b11-9.1+lenny2_1.7R1-2_6b11-9.1+lenny2_1.23.0-3-amd64.tar.bz2" size="25536477" type="application/x-bzip-compressed-tar"/>
+	<archive extract="jre" href="openjdk-6-jre-6b11-9.1+lenny2_6b11-9.1+lenny2_1.7R1-2_6b11-9.1+lenny2_1.23.0-3-amd64.tar.bz2" size="25536477" type="application/x-bzip-compressed-tar"/>
       </implementation>
     </group>
   </group>

--- a/java/openjdk-jdk.xml
+++ b/java/openjdk-jdk.xml
@@ -56,10 +56,10 @@ components using the Java programming language.</description>
         </requires>
         <environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
         <implementation id="sha1new=6b2afc4b5841dfa24b996b321d08b48109b0c5c3" released="2011-05-29" version="6.18-1.8.7-2">
-          <archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b18-1.8.7-2~squeeze1-1.tar.bz2" size="8887727" type="application/x-bzip-compressed-tar"/>
+          <archive extract="java-6-openjdk" href="openjdk-6-jdk-6b18-1.8.7-2~squeeze1-1.tar.bz2" size="8887727" type="application/x-bzip-compressed-tar"/>
         </implementation>
         <implementation id="sha1new=9af7ae7fa806798b1df663c19cddf97f2aa411ca" released="2009-12-28" version="6.11" version-modifier="-9.1-1">
-          <archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2-1.tar.bz2" size="7610012" type="application/x-bzip-compressed-tar"/>
+          <archive extract="java-6-openjdk" href="openjdk-6-jdk-6b11-9.1+lenny2-1.tar.bz2" size="7610012" type="application/x-bzip-compressed-tar"/>
         </implementation>
       </group>
 
@@ -68,7 +68,7 @@ components using the Java programming language.</description>
           <environment insert="bin/java" mode="replace" name="OPENJDK_JRE_JAVA"/>
         </requires>
         <implementation id="sha1new=f2da5d5538d0e3b9d9c0843cb9362e900fd33566" released="2009-12-27" version="6.11-9.1">
-          <archive extract="java-6-openjdk" href="http://repo.roscidus.com/java/openjdk-6-jdk/openjdk-6-jdk-6b11-9.1+lenny2.tar.bz2" size="7602552" type="application/x-bzip-compressed-tar"/>
+          <archive extract="java-6-openjdk" href="openjdk-6-jdk-6b11-9.1+lenny2.tar.bz2" size="7602552" type="application/x-bzip-compressed-tar"/>
           <environment insert="lib" mode="replace" name="OPENJDK_LIBS"/>
         </implementation>
       </group>

--- a/java/swt.xml
+++ b/java/swt.xml
@@ -20,31 +20,31 @@ On OS X, an extra argument needs to be passed to Java. To support OS X, please u
   <category>Development</category>
   <group license="Eclipse Public License and LGPL">
     <implementation arch="Linux-x86_64" id="sha1new=ef03ea4907d195beeb4e20d9427e565f3879b8ff" released="2009-12-31" version="3.5.1">
-      <archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.5.1-gtk-linux-x86_64.tar.bz2" size="1439711" type="application/x-bzip-compressed-tar"/>
+      <archive extract="swt" href="swt-3.5.1-gtk-linux-x86_64.tar.bz2" size="1439711" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation arch="Linux-i386" id="sha1new=d1ac00014927f17d81b0e21e655fc15202d10dd0" released="2009-12-31" version="3.5.1">
-      <archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.5.1-gtk-linux-x86.tar.bz2" size="1341127" type="application/x-bzip-compressed-tar"/>
+      <archive extract="swt" href="swt-3.5.1-gtk-linux-x86.tar.bz2" size="1341127" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation arch="Windows-x86_64" id="sha1new=c4a637dbcdb826bc9db8c36b3c97793f2047fb88" released="2011-01-07" version="3.6.1">
-      <archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.6.1-win32-win32-x86_64.tar.bz2" size="1651871" type="application/x-bzip-compressed-tar"/>
+      <archive extract="swt" href="swt-3.6.1-win32-win32-x86_64.tar.bz2" size="1651871" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation arch="Windows-i386" id="sha1new=5b4d300050a2b972affad3398039114631786e79" released="2011-01-07" version="3.6.1">
-      <archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.6.1-win32-win32-x86.tar.bz2" size="1631349" type="application/x-bzip-compressed-tar"/>
+      <archive extract="swt" href="swt-3.6.1-win32-win32-x86.tar.bz2" size="1631349" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=bb9479c20f7684b9423be7d76194929e9b6fb690" released="2011-01-07" version="3.6.1">
-      <archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.6.1-gtk-linux-x86_64.tar.bz2" size="1582413" type="application/x-bzip-compressed-tar"/>
+      <archive extract="swt" href="swt-3.6.1-gtk-linux-x86_64.tar.bz2" size="1582413" type="application/x-bzip-compressed-tar"/>
     </implementation>
     <implementation arch="Linux-i386" id="sha1new=859ce16046774440401016064a59c2f2280df486" released="2011-01-07" version="3.6.1">
-      <archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.6.1-gtk-linux-x86.tar.bz2" size="1425786" type="application/x-bzip-compressed-tar"/>
+      <archive extract="swt" href="swt-3.6.1-gtk-linux-x86.tar.bz2" size="1425786" type="application/x-bzip-compressed-tar"/>
     </implementation>
 
     <group>
       <environment name="ZEROINSTALL_EXTRA_JAVA_OPTIONS" separator=" " value="-XstartOnFirstThread"/>
       <implementation arch="MacOSX-x86_64" id="sha1new=0304451926f7865550effb10b6e0c11dfd3c5043" released="2011-01-11" version="3.6.1">
-	<archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.6.1-cocoa-macosx-x86_64.tar.bz2" size="1434191" type="application/x-bzip-compressed-tar"/>
+	<archive extract="swt" href="swt-3.6.1-cocoa-macosx-x86_64.tar.bz2" size="1434191" type="application/x-bzip-compressed-tar"/>
       </implementation>
       <implementation arch="MacOSX-i386" id="sha1new=07b352855c107ed97186794f7eb04aa61f2dd9ca" released="2011-01-11" version="3.6.1">
-	<archive extract="swt" href="http://repo.roscidus.com/java/swt/swt-3.6.1-cocoa-macosx.tar.bz2" size="1523076" type="application/x-bzip-compressed-tar"/>
+	<archive extract="swt" href="swt-3.6.1-cocoa-macosx.tar.bz2" size="1523076" type="application/x-bzip-compressed-tar"/>
       </implementation>
     </group>
   </group>

--- a/lib/cairo-dev.xml
+++ b/lib/cairo-dev.xml
@@ -15,10 +15,10 @@ programs that want to compile with Cairo.</description>
     </requires>
 
     <implementation id="sha1new=10c834493ae8034aef70e6f889cc7c82a72fd0a0" released="2012-05-26" version="1.8.10-6">
-      <archive href="http://repo.roscidus.com/lib/cairo-dev/libcairo2-dev-i386-1.8.10-6.tar.bz2" size="559054"/>
+      <archive href="libcairo2-dev-i386-1.8.10-6.tar.bz2" size="559054"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=025c935dcb64ada0cb2f733cc1d8ec129742a55e" released="2012-05-26" version="1.8.10-6">
-      <archive href="http://repo.roscidus.com/lib/cairo-dev/libcairo2-dev-amd64-1.8.10-6.tar.bz2" size="577221"/>
+      <archive href="libcairo2-dev-amd64-1.8.10-6.tar.bz2" size="577221"/>
     </implementation>
   </group>
 

--- a/lib/curl3-gnutls.xml
+++ b/lib/curl3-gnutls.xml
@@ -21,10 +21,10 @@ This is the shared version of libcurl.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation id="sha1new=b78d7c3d298b307165e9f5b839ba78d6f893ee31" released="2010-06-26" version="7.18.2-8">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-i386-7.18.2-8lenny4.tar.bz2" size="212159"/>
+      <archive href="libcurl3-gnutls-i386-7.18.2-8lenny4.tar.bz2" size="212159"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=7e517b40db4abf858d82af82dc59b939130b89b5" released="2010-06-26" version="7.18.2-8">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-amd64-7.18.2-8lenny4.tar.bz2" size="217034"/>
+      <archive href="libcurl3-gnutls-amd64-7.18.2-8lenny4.tar.bz2" size="217034"/>
     </implementation>
   </group>
   <group>
@@ -38,10 +38,10 @@ This is the shared version of libcurl.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=3906d86ed089797c83783f5b50a71c18f3ef7d78" released="2011-05-29" version="7.21.0-1">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-i386-7.21.0-1.tar.bz2" size="261280"/>
+      <archive href="libcurl3-gnutls-i386-7.21.0-1.tar.bz2" size="261280"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=b688a3dc88fe3b50d3840e9dce2587bd9b59f646" released="2011-05-29" version="7.21.0-1">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-amd64-7.21.0-1.tar.bz2" size="268045"/>
+      <archive href="libcurl3-gnutls-amd64-7.21.0-1.tar.bz2" size="268045"/>
     </implementation>
   </group>
   <group>
@@ -55,10 +55,10 @@ This is the shared version of libcurl.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=c28b01d4fb0fdb1dcc9c5f90b9ea58ed59d1d213" released="2011-09-17" version="7.21.0-2">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-i386-7.21.0-2.tar.bz2" size="261535"/>
+      <archive href="libcurl3-gnutls-i386-7.21.0-2.tar.bz2" size="261535"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=ab130cb126c5f38b3971e36aae02fd5c55c5e090" released="2011-09-17" version="7.21.0-2">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-amd64-7.21.0-2.tar.bz2" size="268171"/>
+      <archive href="libcurl3-gnutls-amd64-7.21.0-2.tar.bz2" size="268171"/>
     </implementation>
   </group>
   <group>
@@ -75,10 +75,10 @@ This is the shared version of libcurl.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=b46795b486a7d4c886da888b98f2d54109afd3be" released="2012-03-27" version="7.21.0-2.1">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-i386-7.21.0-2.1+squeeze1.tar.bz2" size="261845"/>
+      <archive href="libcurl3-gnutls-i386-7.21.0-2.1+squeeze1.tar.bz2" size="261845"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=7e6cecf16eee7c1ed049bf72c0c3a2dd5fac5f28" released="2012-03-27" version="7.21.0-2.1">
-      <archive href="http://repo.roscidus.com/lib/curl3-gnutls/libcurl3-gnutls-amd64-7.21.0-2.1+squeeze1.tar.bz2" size="268482"/>
+      <archive href="libcurl3-gnutls-amd64-7.21.0-2.1+squeeze1.tar.bz2" size="268482"/>
     </implementation>
   </group>
 

--- a/lib/expat1.xml
+++ b/lib/expat1.xml
@@ -11,16 +11,16 @@ parsing XML.</description>
   <package-implementation ditributions="Gentoo" package="dev-libs/expat"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=9b893d18c4fa1fcea73f35cd97d9c82c9d8fe2a6" released="2010-04-04" version="2.0.1-4">
-      <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-i386-2.0.1-4+lenny3.tar.bz2" size="102310"/>
+      <archive href="libexpat1-i386-2.0.1-4+lenny3.tar.bz2" size="102310"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=9ee48a6cd154cb051f15043501a3f60f74e906c8" released="2010-04-04" version="2.0.1-4">
-      <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-amd64-2.0.1-4+lenny3.tar.bz2" size="105890"/>
+      <archive href="libexpat1-amd64-2.0.1-4+lenny3.tar.bz2" size="105890"/>
     </implementation>
     <implementation id="sha1new=89d2ce4f09a43eeb3fd6d5de69dfac227adbd7be" released="2011-05-29" version="2.0.1-7">
-      <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-i386-2.0.1-7.tar.bz2" size="107371"/>
+      <archive href="libexpat1-i386-2.0.1-7.tar.bz2" size="107371"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=11b1e69a5e345ebe5e83cb08680a0686172cab9e" released="2011-05-29" version="2.0.1-7">
-      <archive href="http://repo.roscidus.com/lib/expat1/libexpat1-amd64-2.0.1-7.tar.bz2" size="106257"/>
+      <archive href="libexpat1-amd64-2.0.1-7.tar.bz2" size="106257"/>
     </implementation>
   </group>
   <implementation arch="Windows-*" version="1.95.0" released="2000-10-22" license="MIT/X Consortium License" id="1.95.1withdllrenamed">

--- a/lib/gc.xml
+++ b/lib/gc.xml
@@ -15,12 +15,12 @@ intended to be used as a plug-in replacement for C's malloc.</description>
     </requires>
     <group arch="Linux-i386">
       <implementation id="sha1new=a4037bc11ac0ece34b24adea70e7255689f52b19" released="2012-01-02" version="6.8-1.2">
-	<archive href="http://repo.roscidus.com/lib/gc/libgc1c2-i386-1_6.8-1.2.tar.bz2" size="125683"/>
+	<archive href="libgc1c2-i386-1_6.8-1.2.tar.bz2" size="125683"/>
       </implementation>
     </group>
     <group arch="Linux-x86_64">
       <implementation id="sha1new=4803988e733f5c99bbbb6d2b6ddcb95a149d3f52" released="2012-01-02" version="6.8-1.2">
-	<archive href="http://repo.roscidus.com/lib/gc/libgc1c2-amd64-1_6.8-1.2.tar.bz2" size="128933"/>
+	<archive href="libgc1c2-amd64-1_6.8-1.2.tar.bz2" size="128933"/>
       </implementation>
     </group>
   </group>

--- a/lib/gcc1.xml
+++ b/lib/gcc1.xml
@@ -9,10 +9,10 @@ special needs for some languages.</description>
   <package-implementation package="libgcc1"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=2d07d68dbb76ae78946c397d23b5c7d938167f41" released="2011-10-16" version="4.4.5-8">
-      <archive href="http://repo.roscidus.com/lib/gcc1/libgcc1-i386-1_4.4.5-8.tar.bz2" size="51674"/>
+      <archive href="libgcc1-i386-1_4.4.5-8.tar.bz2" size="51674"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=72d044a65851ef9fa91d5f2d2f954d2f918277a8" released="2011-10-16" version="4.4.5-8">
-      <archive href="http://repo.roscidus.com/lib/gcc1/libgcc1-amd64-1_4.4.5-8.tar.bz2" size="42678"/>
+      <archive href="libgcc1-amd64-1_4.4.5-8.tar.bz2" size="42678"/>
     </implementation>
   </group>
 

--- a/lib/glade2.xml
+++ b/lib/glade2.xml
@@ -14,10 +14,10 @@ The interfaces can also be edited with GLADE.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation id="sha1new=15272eeed2f2399dabe965698e2f0071e8d7de24" released="2011-09-11" version="2.6.4-1">
-      <archive href="http://repo.roscidus.com/lib/glade2/libglade2-0-i386-1_2.6.4-1.tar.bz2" size="88025"/>
+      <archive href="libglade2-0-i386-1_2.6.4-1.tar.bz2" size="88025"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=16cdc92f54b0e322a4931883870f60f2e4f319a1" released="2011-09-11" version="2.6.4-1">
-      <archive href="http://repo.roscidus.com/lib/glade2/libglade2-0-amd64-1_2.6.4-1.tar.bz2" size="90219"/>
+      <archive href="libglade2-0-amd64-1_2.6.4-1.tar.bz2" size="90219"/>
     </implementation>
   </group>
 

--- a/lib/gmp3c2.xml
+++ b/lib/gmp3c2.xml
@@ -13,16 +13,16 @@ It has a rich set of functions, and the functions have a regular interface.</des
   <homepage>http://gmplib.org/</homepage>
   <group arch="Linux-i386">
     <implementation id="sha1new=07ea5a9908e71893013736b0afe222cd259d3104" released="2010-06-24" version="4.2.2">
-      <archive href="http://repo.roscidus.com/lib/gmp3c2/libgmp3c2-i386-2_4.2.2+dfsg-3.tar.bz2" size="180918"/>
+      <archive href="libgmp3c2-i386-2_4.2.2+dfsg-3.tar.bz2" size="180918"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=1213339256f457c5b958b3f51f2a846fceac509c" released="2010-06-24" version="4.2.2">
-      <archive href="http://repo.roscidus.com/lib/gmp3c2/libgmp3c2-amd64-2_4.2.2+dfsg-3.tar.bz2" size="166595"/>
+      <archive href="libgmp3c2-amd64-2_4.2.2+dfsg-3.tar.bz2" size="166595"/>
     </implementation>
     <implementation id="sha1new=842fea4dcd8f380f17f079b1eca8636c158b21d1" released="2011-05-29" version="4.3.2">
-      <archive href="http://repo.roscidus.com/lib/gmp3c2/libgmp3c2-i386-2_4.3.2+dfsg-1.tar.bz2" size="232877"/>
+      <archive href="libgmp3c2-i386-2_4.3.2+dfsg-1.tar.bz2" size="232877"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=b20ab6ee8c9f79af433578ba2c17afcb1328c7da" released="2011-05-29" version="4.3.2">
-      <archive href="http://repo.roscidus.com/lib/gmp3c2/libgmp3c2-amd64-2_4.3.2+dfsg-1.tar.bz2" size="230081"/>
+      <archive href="libgmp3c2-amd64-2_4.3.2+dfsg-1.tar.bz2" size="230081"/>
     </implementation>
   </group>
 

--- a/lib/gnutls26.xml
+++ b/lib/gnutls26.xml
@@ -26,10 +26,10 @@ This package contains the runtime libraries.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation id="sha1new=32004067246ee21fc05c2e2946da7d26a1b2bdc9" released="2010-06-26" version="2.4.2-6">
-      <archive href="http://repo.roscidus.com/lib/gnutls26/libgnutls26-i386-2.4.2-6+lenny2.tar.bz2" size="459931"/>
+      <archive href="libgnutls26-i386-2.4.2-6+lenny2.tar.bz2" size="459931"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=e955d6178824f75fbd8178777f6903831d06fc90" released="2010-06-26" version="2.4.2-6">
-      <archive href="http://repo.roscidus.com/lib/gnutls26/libgnutls26-amd64-2.4.2-6+lenny2.tar.bz2" size="508374"/>
+      <archive href="libgnutls26-amd64-2.4.2-6+lenny2.tar.bz2" size="508374"/>
     </implementation>
   </group>
   <group>
@@ -40,20 +40,20 @@ This package contains the runtime libraries.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=df49a5548f26afab506f75718504467bf55ef213" released="2011-05-29" version="2.8.6-1">
-      <archive href="http://repo.roscidus.com/lib/gnutls26/libgnutls26-i386-2.8.6-1.tar.bz2" size="522728"/>
+      <archive href="libgnutls26-i386-2.8.6-1.tar.bz2" size="522728"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=956f537b29f9d72de320ad86e468686df1e1a0ee" released="2011-05-29" version="2.8.6-1">
-      <archive href="http://repo.roscidus.com/lib/gnutls26/libgnutls26-amd64-2.8.6-1.tar.bz2" size="569966"/>
+      <archive href="libgnutls26-amd64-2.8.6-1.tar.bz2" size="569966"/>
     </implementation>
     <group>
       <requires interface="http://repo.roscidus.com/lib/zlib1g">
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
       <implementation arch="Linux-i386" id="sha1new=1a2e7e981c336d9b1e5eebc23c24d66d9da157e6" released="2012-03-27" version="2.8.6-1">
-      <archive href="http://repo.roscidus.com/lib/gnutls26/libgnutls26-i386-2.8.6-1+squeeze2.tar.bz2" size="522997"/>
+      <archive href="libgnutls26-i386-2.8.6-1+squeeze2.tar.bz2" size="522997"/>
     </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=14733b1cffcf5393f178b8fd13fe0d17aa468630" released="2012-03-27" version="2.8.6-1">
-      <archive href="http://repo.roscidus.com/lib/gnutls26/libgnutls26-amd64-2.8.6-1+squeeze2.tar.bz2" size="569973"/>
+      <archive href="libgnutls26-amd64-2.8.6-1+squeeze2.tar.bz2" size="569973"/>
     </implementation>
     </group>
   </group>

--- a/lib/gtkmm.xml
+++ b/lib/gtkmm.xml
@@ -30,12 +30,12 @@ This package contains shared libraries.</description>
 
     <group arch="Linux-i386">
       <implementation id="sha1new=21531defeb19a58397b52a2c3562b0e170db7f72" released="2012-01-01" version="2.20.3-1">
-	<archive href="http://repo.roscidus.com/lib/gtkmm/libgtkmm-2.4-1c2a-i386-1_2.20.3-1.tar.bz2" size="1276223"/>
+	<archive href="libgtkmm-2.4-1c2a-i386-1_2.20.3-1.tar.bz2" size="1276223"/>
       </implementation>
     </group>
     <group arch="Linux-x86_64">
       <implementation id="sha1new=bb479194c2204b6cea6ada917fc46725e9c0afbf" released="2012-01-01" version="2.20.3-1">
-	<archive href="http://repo.roscidus.com/lib/gtkmm/libgtkmm-2.4-1c2a-amd64-1_2.20.3-1.tar.bz2" size="1206132"/>
+	<archive href="libgtkmm-2.4-1c2a-amd64-1_2.20.3-1.tar.bz2" size="1206132"/>
       </implementation>
     </group>
   </group>

--- a/lib/krb53.xml
+++ b/lib/krb53.xml
@@ -21,17 +21,17 @@ Kerberos clients.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation id="sha1new=2a8dbfd1181e06f6c1903ffe209da7dedc92cfb9" released="2010-06-26" version="1.6">
-      <archive href="http://repo.roscidus.com/lib/krb53/libkrb53-i386-1.6.dfsg.4~beta1-5lenny4.tar.bz2" size="464267"/>
+      <archive href="libkrb53-i386-1.6.dfsg.4~beta1-5lenny4.tar.bz2" size="464267"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=35b78e682f6f51e05ccdd9155698a0667ff9aea6" released="2010-06-26" version="1.6">
-      <archive href="http://repo.roscidus.com/lib/krb53/libkrb53-amd64-1.6.dfsg.4~beta1-5lenny4.tar.bz2" size="508704"/>
+      <archive href="libkrb53-amd64-1.6.dfsg.4~beta1-5lenny4.tar.bz2" size="508704"/>
     </implementation>
   </group>
   <implementation arch="Linux-*" id="sha1new=8510fa7b47a00d8f45a17a02e2736ff4361c144e" released="2011-05-29" version="1.8.3">
-      <archive href="http://repo.roscidus.com/lib/krb53/libkrb53-i386-1.8.3+dfsg-4.tar.bz2" size="1380447"/>
+      <archive href="libkrb53-i386-1.8.3+dfsg-4.tar.bz2" size="1380447"/>
     </implementation>
   <implementation arch="Linux-*" id="sha1new=ab541b8fecb59f40b1eea7e9e1b5cbfe660b9cc9" released="2011-09-17" version="1.8.3">
-      <archive href="http://repo.roscidus.com/lib/krb53/libkrb53-1.8.3+dfsg-4squeeze1.tar.bz2" size="1380605"/>
+      <archive href="libkrb53-1.8.3+dfsg-4squeeze1.tar.bz2" size="1380605"/>
     </implementation>
 
 </interface>

--- a/lib/ldap-2.4-2.xml
+++ b/lib/ldap-2.4-2.xml
@@ -14,16 +14,16 @@ Access Protocol) servers and clients.</description>
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation id="sha1new=730a3697669531a75017f775ff5a6ebb88b8cd5e" released="2011-05-29" version="2.4.23-7">
-      <archive href="http://repo.roscidus.com/lib/ldap-2.4-2/libldap-2.4-2-i386-2.4.23-7.tar.bz2" size="192173"/>
+      <archive href="libldap-2.4-2-i386-2.4.23-7.tar.bz2" size="192173"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=f26bb500bcf557a2c636ac934212baceeec3c6bd" released="2011-05-29" version="2.4.23-7">
-      <archive href="http://repo.roscidus.com/lib/ldap-2.4-2/libldap-2.4-2-amd64-2.4.23-7.tar.bz2" size="208883"/>
+      <archive href="libldap-2.4-2-amd64-2.4.23-7.tar.bz2" size="208883"/>
     </implementation>
     <implementation id="sha1new=013a46023b8fab8930567f146772aa24954845c9" released="2011-09-17" version="2.4.23-7.2">
-      <archive href="http://repo.roscidus.com/lib/ldap-2.4-2/libldap-2.4-2-i386-2.4.23-7.2.tar.bz2" size="192637"/>
+      <archive href="libldap-2.4-2-i386-2.4.23-7.2.tar.bz2" size="192637"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=54e46c67506f2b4be843f6103587e966a66cf4ec" released="2011-09-17" version="2.4.23-7.2">
-      <archive href="http://repo.roscidus.com/lib/ldap-2.4-2/libldap-2.4-2-amd64-2.4.23-7.2.tar.bz2" size="209216"/>
+      <archive href="libldap-2.4-2-amd64-2.4.23-7.2.tar.bz2" size="209216"/>
     </implementation>
   </group>
 

--- a/lib/mpfr1ldbl.xml
+++ b/lib/mpfr1ldbl.xml
@@ -15,10 +15,10 @@ precision floating-point arithmetic (53-bit mantissa).</description>
       <environment insert="lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation id="sha1new=564b2940f6df9993292e80bb40588b6aacdc2d66" released="2010-06-24" version="2.3.1">
-      <archive href="http://repo.roscidus.com/lib/mpfr1ldbl/libmpfr1ldbl-i386-2.3.1.dfsg.1-2.tar.bz2" size="342210"/>
+      <archive href="libmpfr1ldbl-i386-2.3.1.dfsg.1-2.tar.bz2" size="342210"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=d54e8b7a69491bfa8ea1c750bc2db9fbd75f5f54" released="2010-06-24" version="2.3.1">
-      <archive href="http://repo.roscidus.com/lib/mpfr1ldbl/libmpfr1ldbl-amd64-2.3.1.dfsg.1-2.tar.bz2" size="354414"/>
+      <archive href="libmpfr1ldbl-amd64-2.3.1.dfsg.1-2.tar.bz2" size="354414"/>
     </implementation>
   </group>
 

--- a/lib/png12-0.xml
+++ b/lib/png12-0.xml
@@ -12,20 +12,20 @@ using libpng.</description>
   <package-implementation package="libpng12"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=c33007f8f0185af570fe3c37f391b5832c8cb2de" released="2011-10-01" version="1.2.44-1">
-      <archive href="http://repo.roscidus.com/lib/png12-0/libpng12-0-i386-1.2.44-1+squeeze1.tar.bz2" size="106531"/>
+      <archive href="libpng12-0-i386-1.2.44-1+squeeze1.tar.bz2" size="106531"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=24a3bed36ab3898dab469b4faa8a7216f2813cce" released="2011-10-01" version="1.2.44-1">
-      <archive href="http://repo.roscidus.com/lib/png12-0/libpng12-0-amd64-1.2.44-1+squeeze1.tar.bz2" size="106552"/>
+      <archive href="libpng12-0-amd64-1.2.44-1+squeeze1.tar.bz2" size="106552"/>
     </implementation>
     <group>
       <requires interface="http://repo.roscidus.com/lib/zlib1g">
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
       <implementation id="sha1new=8390965d5ff42850c411b6902a72b5f7683ae1ae" released="2012-03-27" version="1.2.44-1">
-      <archive href="http://repo.roscidus.com/lib/png12-0/libpng12-0-i386-1.2.44-1+squeeze3.tar.bz2" size="106547"/>
+      <archive href="libpng12-0-i386-1.2.44-1+squeeze3.tar.bz2" size="106547"/>
     </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=99450d9b55c1ffc3d05432f6424d804a055f331d" released="2012-03-27" version="1.2.44-1">
-      <archive href="http://repo.roscidus.com/lib/png12-0/libpng12-0-amd64-1.2.44-1+squeeze3.tar.bz2" size="106559"/>
+      <archive href="libpng12-0-amd64-1.2.44-1+squeeze3.tar.bz2" size="106559"/>
     </implementation>
     </group>
   </group>

--- a/lib/popt.xml
+++ b/lib/popt.xml
@@ -13,10 +13,10 @@ strings into argv[] arrays using shell-like rules.
 This package contains the runtime library and locale data.</description>
   <package-implementation package="libpopt0"/>
   <implementation arch="Linux-i386" id="sha1new=362577ba8014c27fa70d458512af35b56cdf5ea6" released="2012-05-26" version="1.16-1">
-      <archive href="http://repo.roscidus.com/lib/popt/libpopt0-i386-1.16-1.tar.bz2" size="51588"/>
+      <archive href="libpopt0-i386-1.16-1.tar.bz2" size="51588"/>
     </implementation>
   <implementation arch="Linux-x86_64" id="sha1new=856e07e63b6130b96ab39bf8dfc3ac5e3d18db96" released="2012-05-26" version="1.16-1">
-      <archive href="http://repo.roscidus.com/lib/popt/libpopt0-amd64-1.16-1.tar.bz2" size="53008"/>
+      <archive href="libpopt0-amd64-1.16-1.tar.bz2" size="53008"/>
     </implementation>
 
 </interface>

--- a/lib/readline6.xml
+++ b/lib/readline6.xml
@@ -12,10 +12,10 @@ recalling lines of previously typed input.</description>
   <package-implementation package="libreadline6"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=284c4bac4d43f41fad32250614a9eab5202a55b3" released="2011-06-25" version="6.1-3">
-      <archive href="http://repo.roscidus.com/lib/readline6/libreadline6-i386-6.1-3.tar.bz2" size="134310"/>
+      <archive href="libreadline6-i386-6.1-3.tar.bz2" size="134310"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=b3329db54dddfcf5febd40f55b28227d3f7fa4a8" released="2011-06-25" version="6.1-3">
-      <archive href="http://repo.roscidus.com/lib/readline6/libreadline6-amd64-6.1-3.tar.bz2" size="148959"/>
+      <archive href="libreadline6-amd64-6.1-3.tar.bz2" size="148959"/>
     </implementation>
   </group>
 

--- a/lib/stdc++6.xml
+++ b/lib/stdc++6.xml
@@ -17,10 +17,10 @@ in g++-3.0.</description>
     </requires>
 
     <implementation id="sha1new=3ea473cbd976fac4360478603fd301fc387ec21b" released="2011-10-01" version="4.4.5-8">
-      <archive href="http://repo.roscidus.com/lib/stdc++6/libstdc++6-i386-4.4.5-8.tar.bz2" size="329917"/>
+      <archive href="libstdc++6-i386-4.4.5-8.tar.bz2" size="329917"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=addf2265c9a59a45aa95db15d7458d00a65bfe96" released="2011-10-01" version="4.4.5-8">
-      <archive href="http://repo.roscidus.com/lib/stdc++6/libstdc++6-amd64-4.4.5-8.tar.bz2" size="324558"/>
+      <archive href="libstdc++6-amd64-4.4.5-8.tar.bz2" size="324558"/>
     </implementation>
   </group>
 

--- a/lib/tasn1-3.xml
+++ b/lib/tasn1-3.xml
@@ -16,22 +16,22 @@ This package contains runtime libraries.</description>
   <package-implementation package="libtasn1-3"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=cf5f598f8cb5697cf3c163b056b7ab48878e8b5c" released="2010-06-26" version="1.4-1">
-      <archive href="http://repo.roscidus.com/lib/tasn1-3/libtasn1-3-i386-1.4-1.tar.bz2" size="58156"/>
+      <archive href="libtasn1-3-i386-1.4-1.tar.bz2" size="58156"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=420f1e2373c433312e795a1f3dbd304f8143e4f4" released="2010-06-26" version="1.4-1">
-      <archive href="http://repo.roscidus.com/lib/tasn1-3/libtasn1-3-amd64-1.4-1.tar.bz2" size="60431"/>
+      <archive href="libtasn1-3-amd64-1.4-1.tar.bz2" size="60431"/>
     </implementation>
     <implementation id="sha1new=7e12b9c035a728598a23a418c5e6931b9182c56f" released="2011-05-29" version="2.7-1">
-      <archive href="http://repo.roscidus.com/lib/tasn1-3/libtasn1-3-i386-2.7-1.tar.bz2" size="62504"/>
+      <archive href="libtasn1-3-i386-2.7-1.tar.bz2" size="62504"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=4602c038987469545054d4eabaab0e0944839062" released="2011-05-29" version="2.7-1">
-      <archive href="http://repo.roscidus.com/lib/tasn1-3/libtasn1-3-amd64-2.7-1.tar.bz2" size="64247"/>
+      <archive href="libtasn1-3-amd64-2.7-1.tar.bz2" size="64247"/>
     </implementation>
     <implementation id="sha1new=7b30905ae8c403b65c7b78adcbca7dd82dc0eb1b" released="2012-03-27" version="2.7-1">
-      <archive href="http://repo.roscidus.com/lib/tasn1-3/libtasn1-3-i386-2.7-1+squeeze+1.tar.bz2" size="62669"/>
+      <archive href="libtasn1-3-i386-2.7-1+squeeze+1.tar.bz2" size="62669"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=a616f0d39c1025ffa95137a33342af80f16886cc" released="2012-03-27" version="2.7-1">
-      <archive href="http://repo.roscidus.com/lib/tasn1-3/libtasn1-3-amd64-2.7-1+squeeze+1.tar.bz2" size="64325"/>
+      <archive href="libtasn1-3-amd64-2.7-1+squeeze+1.tar.bz2" size="64325"/>
     </implementation>
   </group>
 

--- a/lib/x-ice-dev.xml
+++ b/lib/x-ice-dev.xml
@@ -18,7 +18,7 @@ More information about X.Org can be found at: &lt;URL:http://xorg.freedesktop.or
       <environment insert="lib/pkgconfig" name="PKG_CONFIG_PATH"/>
     </requires>
     <implementation id="sha1new=06a4f9ece282b4ed0644261210b4b9333d3c6da6" released="2010-08-12" version="1.0.4-1">
-      <archive href="http://repo.roscidus.com/lib/x-ice-dev/libice-dev-i386-2_1.0.4-1.tar.bz2" size="52221"/>
+      <archive href="libice-dev-i386-2_1.0.4-1.tar.bz2" size="52221"/>
     </implementation>
   </group>
   <group>
@@ -26,7 +26,7 @@ More information about X.Org can be found at: &lt;URL:http://xorg.freedesktop.or
       <environment insert="lib/pkgconfig" name="PKG_CONFIG_PATH"/>
     </requires>
     <implementation arch="Linux-x86_64" id="sha1new=f718ecf1b9d55879794d79ea91e534dba545d478" released="2010-08-12" version="1.0.4-1">
-      <archive href="http://repo.roscidus.com/lib/x-ice-dev/libice-dev-amd64-2_1.0.4-1.tar.bz2" size="56596"/>
+      <archive href="libice-dev-amd64-2_1.0.4-1.tar.bz2" size="56596"/>
     </implementation>
   </group>
   <group>
@@ -34,10 +34,10 @@ More information about X.Org can be found at: &lt;URL:http://xorg.freedesktop.or
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=7a3d73292920853f846035e27d1b23e473aeeb2d" released="2011-05-29" version="1.0.6-2">
-      <archive href="http://repo.roscidus.com/lib/x-ice-dev/libice-dev-i386-2_1.0.6-2.tar.bz2" size="56027"/>
+      <archive href="libice-dev-i386-2_1.0.6-2.tar.bz2" size="56027"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=1a6aa1ed8c5e479bdb397be19781517808855703" released="2011-05-29" version="1.0.6-2">
-      <archive href="http://repo.roscidus.com/lib/x-ice-dev/libice-dev-amd64-2_1.0.6-2.tar.bz2" size="60874"/>
+      <archive href="libice-dev-amd64-2_1.0.6-2.tar.bz2" size="60874"/>
     </implementation>
   </group>
 

--- a/lib/x-sm-dev.xml
+++ b/lib/x-sm-dev.xml
@@ -22,7 +22,7 @@ This module can be found at git://anongit.freedesktop.org/git/xorg/lib/libSM</de
       <environment insert="lib/pkgconfig" name="PKG_CONFIG_PATH"/>
     </requires>
     <implementation id="sha1new=e26870cf728fff1f84a32fb53c76342b4e48c11a" released="2010-08-12" version="1.0.3-2">
-      <archive href="http://repo.roscidus.com/lib/x-sm-dev/libsm-dev-i386-2_1.0.3-2.tar.bz2" size="24583"/>
+      <archive href="libsm-dev-i386-2_1.0.3-2.tar.bz2" size="24583"/>
     </implementation>
   </group>
   <group arch="Linux-x86_64">
@@ -30,7 +30,7 @@ This module can be found at git://anongit.freedesktop.org/git/xorg/lib/libSM</de
       <environment insert="lib/pkgconfig" name="PKG_CONFIG_PATH"/>
     </requires>
     <implementation id="sha1new=9f7efcbdc1ba0384c3f76e400a28e014d63705c9" released="2010-08-12" version="1.0.3-2">
-      <archive href="http://repo.roscidus.com/lib/x-sm-dev/libsm-dev-amd64-2_1.0.3-2.tar.bz2" size="26124"/>
+      <archive href="libsm-dev-amd64-2_1.0.3-2.tar.bz2" size="26124"/>
     </implementation>
   </group>
   <group>
@@ -41,10 +41,10 @@ This module can be found at git://anongit.freedesktop.org/git/xorg/lib/libSM</de
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
     <implementation arch="Linux-i386" id="sha1new=5f5c0729c1a04ed2f3a7f87e59b8abefbfaf12ef" released="2011-05-29" version="1.1.1-1">
-      <archive href="http://repo.roscidus.com/lib/x-sm-dev/libsm-dev-i386-2_1.1.1-1.tar.bz2" size="26574"/>
+      <archive href="libsm-dev-i386-2_1.1.1-1.tar.bz2" size="26574"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=539e5829034005f02ff033acb08a2a76e61128e7" released="2011-05-29" version="1.1.1-1">
-      <archive href="http://repo.roscidus.com/lib/x-sm-dev/libsm-dev-amd64-2_1.1.1-1.tar.bz2" size="28006"/>
+      <archive href="libsm-dev-amd64-2_1.1.1-1.tar.bz2" size="28006"/>
     </implementation>
   </group>
 

--- a/lib/x11proto-core-dev.xml
+++ b/lib/x11proto-core-dev.xml
@@ -19,13 +19,13 @@ This package is built from the X.org xproto proto module.</description>
   <package-implementation package="x11proto-core-dev"/>
   <group arch="Linux-*">
     <implementation id="sha1new=6e426da8203b60a1f32e458cc86efc58abb2ea78" released="2010-08-12" version="7.0.12-1">
-      <archive href="http://repo.roscidus.com/lib/x11proto-core-dev/x11proto-core-dev-i386-7.0.12-1.tar.bz2" size="79688"/>
+      <archive href="x11proto-core-dev-i386-7.0.12-1.tar.bz2" size="79688"/>
     </implementation>
     <implementation id="sha1new=40638953ec0bab851731f83c506152ddc16d7370" released="2011-05-29" version="7.0.16-1">
-      <archive href="http://repo.roscidus.com/lib/x11proto-core-dev/x11proto-core-dev-i386-7.0.16-1.tar.bz2" size="83503"/>
+      <archive href="x11proto-core-dev-i386-7.0.16-1.tar.bz2" size="83503"/>
     </implementation>
     <implementation id="sha1new=e6ad2e80bb943ba7bbf81a66313b22a524295b46" released="2011-05-29" version="7.0.16-1">
-      <archive href="http://repo.roscidus.com/lib/x11proto-core-dev/x11proto-core-dev-7.0.16-1.tar.bz2" size="83545"/>
+      <archive href="x11proto-core-dev-7.0.16-1.tar.bz2" size="83545"/>
     </implementation>
   </group>
 

--- a/lib/xml2.xml
+++ b/lib/xml2.xml
@@ -15,20 +15,20 @@ such XML data files.</description>
   <package-implementation package="libxml2"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=f248e00cdda7e14ec148cd7120f575c4650157fe" released="2011-09-17" version="2.7.8">
-      <archive href="http://repo.roscidus.com/lib/xml2/libxml2-i386-2.7.8.dfsg-2+squeeze1.tar.bz2" size="808089"/>
+      <archive href="libxml2-i386-2.7.8.dfsg-2+squeeze1.tar.bz2" size="808089"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=0eec0a01c3d12de6f07faf138df1a24634d7326a" released="2011-09-17" version="2.7.8">
-      <archive href="http://repo.roscidus.com/lib/xml2/libxml2-amd64-2.7.8.dfsg-2+squeeze1.tar.bz2" size="861925"/>
+      <archive href="libxml2-amd64-2.7.8.dfsg-2+squeeze1.tar.bz2" size="861925"/>
     </implementation>
     <group>
       <requires interface="http://repo.roscidus.com/lib/zlib1g">
       <environment insert="usr/lib" name="LD_LIBRARY_PATH"/>
     </requires>
       <implementation id="sha1new=a7e5d754ed506f4e567fabeae05884d073a69433" released="2012-03-27" version="2.7.8">
-      <archive href="http://repo.roscidus.com/lib/xml2/libxml2-i386-2.7.8.dfsg-2+squeeze3.tar.bz2" size="809575"/>
+      <archive href="libxml2-i386-2.7.8.dfsg-2+squeeze3.tar.bz2" size="809575"/>
     </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=9e9d62c9b0aec9ad55de90c0df16e08a8d29f373" released="2012-03-27" version="2.7.8">
-      <archive href="http://repo.roscidus.com/lib/xml2/libxml2-amd64-2.7.8.dfsg-2+squeeze3.tar.bz2" size="862772"/>
+      <archive href="libxml2-amd64-2.7.8.dfsg-2+squeeze3.tar.bz2" size="862772"/>
     </implementation>
     </group>
   </group>

--- a/lib/zlib1g.xml
+++ b/lib/zlib1g.xml
@@ -9,10 +9,10 @@ in gzip and PKZIP. This package includes the shared library.</description>
   <package-implementation package="zlib"/>
   <group arch="Linux-i386">
     <implementation id="sha1new=6a4df6afbe70ed62b3ba3cc813b20424e500af89" released="2011-10-16" version="1.2.3.4">
-      <archive href="http://repo.roscidus.com/lib/zlib1g/zlib1g-i386-1_1.2.3.4.dfsg-3.tar.bz2" size="78330"/>
+      <archive href="zlib1g-i386-1_1.2.3.4.dfsg-3.tar.bz2" size="78330"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=b02aa6a2f81fb5d1925d2879128be5fa249c6bd4" released="2011-10-16" version="1.2.3.4">
-      <archive href="http://repo.roscidus.com/lib/zlib1g/zlib1g-amd64-1_1.2.3.4.dfsg-3.tar.bz2" size="81958"/>
+      <archive href="zlib1g-amd64-1_1.2.3.4.dfsg-3.tar.bz2" size="81958"/>
     </implementation>
   </group>
 

--- a/python/sphinx.xml
+++ b/python/sphinx.xml
@@ -25,7 +25,7 @@ languages as well.</description>
     <requires interface="http://gfxmonk.net/dist/0install/jinja2.xml"/>
 
     <implementation doc-dir="doc" id="sha1new=7dd5e02109d6906134d10ea06f8d892269a1e83f" license="OSI Approved :: BSD License (revised)" released="2013-01-18" version="1.1.3">
-      <archive extract="Sphinx-1.1.3" href="http://repo.roscidus.com/python/sphinx/Sphinx-1.1.3.tar.gz" size="2632059" type="application/x-compressed-tar"/>
+      <archive extract="Sphinx-1.1.3" href="Sphinx-1.1.3.tar.gz" size="2632059" type="application/x-compressed-tar"/>
     </implementation>
   </group>
 </interface>

--- a/security/gnupg.xml
+++ b/security/gnupg.xml
@@ -27,20 +27,20 @@ because it uses IDEA (which is patented worldwide).</description>
 
   <group arch="Linux-i386" license="GPL v3 (GNU General Public License)" main="bin/gpg">
     <implementation id="sha1new=af4d8a604323238a092e4ed3cae9372f9d3302c4" released="2010-06-06" version="1.4.9-3">
-      <archive href="http://repo.roscidus.com/security/gnupg/gnupg-i386-1.4.9-3+lenny1.tar.bz2" size="1571178"/>
+      <archive href="gnupg-i386-1.4.9-3+lenny1.tar.bz2" size="1571178"/>
     </implementation>
     <implementation arch="Linux-x86_64" id="sha1new=e868aac11bfab00c3f1c43f9780c757fb86e5819" released="2010-06-06" version="1.4.9-3">
-      <archive href="http://repo.roscidus.com/security/gnupg/gnupg-amd64-1.4.9-3+lenny1.tar.bz2" size="1620186"/>
+      <archive href="gnupg-amd64-1.4.9-3+lenny1.tar.bz2" size="1620186"/>
     </implementation>
     <group>
       <requires interface="http://repo.roscidus.com/lib/readline6">
         <environment insert="lib" name="LD_LIBRARY_PATH"/>
       </requires>
       <implementation id="sha1new=4a3636d68e9a64fe2b0b20c480a1af2218830b60" released="2011-05-29" version="1.4.10-4">
-        <archive href="http://repo.roscidus.com/security/gnupg/gnupg-i386-1.4.10-4.tar.bz2" size="1711464"/>
+        <archive href="gnupg-i386-1.4.10-4.tar.bz2" size="1711464"/>
       </implementation>
       <implementation arch="Linux-x86_64" id="sha1new=7b41bfd5e28db2298adee2f5c93d3233b7d94842" released="2011-05-29" version="1.4.10-4">
-        <archive href="http://repo.roscidus.com/security/gnupg/gnupg-amd64-1.4.10-4.tar.bz2" size="1769667"/>
+        <archive href="gnupg-amd64-1.4.10-4.tar.bz2" size="1769667"/>
       </implementation>
     </group>
   </group>

--- a/utils/graphviz.xml
+++ b/utils/graphviz.xml
@@ -46,7 +46,7 @@
     <command name="sfdp" path="bin/sfdp.exe"/>
 
     <implementation id="sha1new=b9ad8643984d120799c43f3d85d58f2653f87955" released="2011-04-21" version="2.27.20110421.0445" stability="stable">
-      <archive extract="release" href="http://repo.roscidus.com/utils/graphviz/graphviz-bin-2.27.20110421.0445.zip" size="49035660" type="application/zip"/>
+      <archive extract="release" href="graphviz-bin-2.27.20110421.0445.zip" size="49035660" type="application/zip"/>
     </implementation>
     <implementation id="sha1new=23991c6e6cf53d7b401c61aff71575ff326e3bca" released="2014-04-13" version="2.38" stability="stable">
       <manifest-digest sha256new="BFQPX4FKOIBNJRC34KOWGMANFIT3WNZ5N6DXUVDOUEJZMRFYLVYQ"/>


### PR DESCRIPTION
Some of them predated the current naming system (and got missed at first during the migration).