### PR TITLE
grep needs libintl3.dll to run

### DIFF
--- a/utils/grep.xml
+++ b/utils/grep.xml
@@ -13,6 +13,9 @@
     <requires interface="http://repo.roscidus.com/devel/libintl">
       <environment insert="bin" name="PATH"/>
     </requires>
+    <requires interface="http://repo.roscidus.com/devel/gettext">
+      <environment insert="bin" name="PATH"/>
+    </requires>
     <requires interface="http://repo.roscidus.com/lib/libiconv">
       <environment insert="bin" name="PATH"/>
     </requires>


### PR DESCRIPTION
grep fails to run due to missing libintl3.dll because of a fix I made to iconv